### PR TITLE
chore: set compartment names and identifiers

### DIFF
--- a/iPfal19.xml
+++ b/iPfal19.xml
@@ -36,985 +36,985 @@
       <compartment constant="true" id="v" name="vacuole"/>
     </listOfCompartments>
     <listOfSpecies>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_10fthf_c" name="10_Formyltetrahydrofolate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C20H21N7O7"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_12dgr120_c" name="1_2_Diacyl_sn_glycerol_didodecanoyl_n_C120" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C27H52O5"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_12dgr120_e" name="1_2_Diacyl_sn_glycerol_didodecanoyl_n_C120" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="C27H52O5"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_12dgr140_c" name="1_2_Diacyl_sn_glycerol_ditetradecanoyl_n_C140" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C31H60O5"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_12dgr140_e" name="1_2_Diacyl_sn_glycerol_ditetradecanoyl_n_C140" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="C31H60O5"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_12dgr141_c" name="1_2_Diacyl_sn_glycerol_ditetradec_7_enoyl_n_C141" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C31H56O5"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_12dgr141_e" name="1_2_Diacyl_sn_glycerol_ditetradec_7_enoyl_n_C141" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="C31H56O5"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_12dgr160_c" name="1_2_Diacyl_sn_glycerol_dihexadecanoyl_n_C160" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C35H68O5"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_12dgr160_e" name="1_2_Diacyl_sn_glycerol_dihexadecanoyl_n_C160" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="C35H68O5"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_12dgr161_c" name="1_2_Diacyl_sn_glycerol_dihexadec_9_enoyl_n_C161" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C35H64O5"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_12dgr161_e" name="1_2_Diacyl_sn_glycerol_dihexadec_9_enoyl_n_C161" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="C35H64O5"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_12dgr180_c" name="1_2_Diacyl_sn_glycerol_dioctadecanoyl_n_C180" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C39H76O5"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_12dgr180_e" name="1_2_Diacyl_sn_glycerol_dioctadecanoyl_n_C180" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="C39H76O5"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_12dgr181_c" name="1_2_Diacyl_sn_glycerol_dioctadec_11_enoyl_n_C181" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C39H72O5"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_12dgr181_e" name="1_2_Diacyl_sn_glycerol_dioctadec_11_enoyl_n_C181" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="C39H72O5"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_13dpg_c" name="3_Phospho_D_glyceroyl_phosphate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C3H4O10P2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_1agpe120_c" name="1_Acyl_sn_glycero_3_phosphoethanolamine_n_C120" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C17H36NO7P1"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_1agpe140_c" name="1_Acyl_sn_glycero_3_phosphoethanolamine_n_C140" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C19H40NO7P1"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_1agpe141_c" name="1_Acyl_sn_glycero_3_phosphoethanolamine_n_C141" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C19H38NO7P1"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_1agpe160_c" name="1_Acyl_sn_glycero_3_phosphoethanolamine_n_C160" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C21H44NO7P1"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_1agpe161_c" name="1_Acyl_sn_glycero_3_phosphoethanolamine_n_C161" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C21H42NO7P1"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_1agpe180_c" name="1_Acyl_sn_glycero_3_phosphoethanolamine_n_C180" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C23H48NO7P1"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_1agpe181_c" name="1_Acyl_sn_glycero_3_phosphoethanolamine_n_C181" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C23H46NO7P1"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_1agpg120_c" name="1_Acyl_sn_glycero_3_phosphoglycerol_n_C120" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C18H36O9P1"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_1agpg140_c" name="1_Acyl_sn_glycero_3_phosphoglycerol_n_C140" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C20H40O9P1"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_1agpg141_c" name="1_Acyl_sn_glycero_3_phosphoglycerol_n_C141" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C20H38O9P1"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_1agpg160_c" name="1_Acyl_sn_glycero_3_phosphoglycerol_n_C160" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C22H44O9P1"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_1agpg161_c" name="1_Acyl_sn_glycero_3_phosphoglycerol_n_C161" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C22H42O9P1"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_1agpg180_c" name="1_Acyl_sn_glycero_3_phosphoglycerol_n_C180" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C24H48O9P1"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_1agpg181_c" name="1_Acyl_sn_glycero_3_phosphoglycerol_n_C181" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C24H46O9P1"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_1ddecg3p_ap" name="1_dodecanoyl_sn_glycerol_3_phosphate" compartment="apicoplast" fbc:charge="0" fbc:chemicalFormula="C15H29O7P1"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_1ddecg3p_c" name="1_dodecanoyl_sn_glycerol_3_phosphate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C15H29O7P1"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_1hdec9eg3p_ap" name="1_hexadec_9_enoyl_sn_glycerol_3_phosphate" compartment="apicoplast" fbc:charge="0" fbc:chemicalFormula="C19H35O7P1"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_1hdec9eg3p_c" name="1_hexadec_9_enoyl_sn_glycerol_3_phosphate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C19H35O7P1"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_1hdecg3p_ap" name="1_hexadecanoyl_sn_glycerol_3_phosphate" compartment="apicoplast" fbc:charge="0" fbc:chemicalFormula="C19H37O7P1"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_1hdecg3p_c" name="1_hexadecanoyl_sn_glycerol_3_phosphate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C19H37O7P1"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_1odec11eg3p_ap" name="1_octadec_11_enoyl_sn_glycerol_3_phosphate" compartment="apicoplast" fbc:charge="0" fbc:chemicalFormula="C21H39O7P1"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_1odec11eg3p_c" name="1_octadec_11_enoyl_sn_glycerol_3_phosphate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C21H39O7P1"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_1odecg3p_ap" name="1_octadecanoyl_sn_glycerol_3_phosphate" compartment="apicoplast" fbc:charge="0" fbc:chemicalFormula="C21H41O7P1"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_1odecg3p_c" name="1_octadecanoyl_sn_glycerol_3_phosphate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C21H41O7P1"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_1pyr5c_c" name="1_Pyrroline_5_carboxylate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C5H6NO2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_1tdec7eg3p_ap" name="1_tetradec_7_enoyl_sn_glycerol_3_phosphate" compartment="apicoplast" fbc:charge="0" fbc:chemicalFormula="C17H31O7P1"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_1tdec7eg3p_c" name="1_tetradec_7_enoyl_sn_glycerol_3_phosphate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C17H31O7P1"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_1tdecg3p_ap" name="1_tetradecanoyl_sn_glycerol_3_phosphate" compartment="apicoplast" fbc:charge="0" fbc:chemicalFormula="C17H33O7P1"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_1tdecg3p_c" name="1_tetradecanoyl_sn_glycerol_3_phosphate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C17H33O7P1"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_25aics_c" name="S_2_5_Amino_1_5_phospho_D_ribosyl_imidazole_4_carboxamidosuccinate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C13H15N4O12P"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_2agpe120_c" name="2_Acyl_sn_glycero_3_phosphoethanolamine_n_C120" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C17H36NO7P1"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_2agpe140_c" name="2_Acyl_sn_glycero_3_phosphoethanolamine_n_C140" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C19H40NO7P1"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_2agpe141_c" name="2_Acyl_sn_glycero_3_phosphoethanolamine_n_C141" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C19H38NO7P1"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_2agpe160_c" name="2_Acyl_sn_glycero_3_phosphoethanolamine_n_C160" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C21H44NO7P1"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_2agpe161_c" name="2_Acyl_sn_glycero_3_phosphoethanolamine_n_C161" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C21H42NO7P1"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_2agpe180_c" name="2_Acyl_sn_glycero_3_phosphoethanolamine_n_C180" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C23H48NO7P1"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_2agpe181_c" name="2_Acyl_sn_glycero_3_phosphoethanolamine_n_C181" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C23H46NO7P1"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_2agpg120_c" name="2_Acyl_sn_glycero_3_phosphoglycerol_n_C120" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C18H36O9P1"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_2agpg140_c" name="2_Acyl_sn_glycero_3_phosphoglycerol_n_C140" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C20H40O9P1"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_2agpg141_c" name="2_Acyl_sn_glycero_3_phosphoglycerol_n_C141" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C20H38O9P1"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_2agpg160_c" name="2_Acyl_sn_glycero_3_phosphoglycerol_n_C160" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C22H44O9P1"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_2agpg161_c" name="2_Acyl_sn_glycero_3_phosphoglycerol_n_C161" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C22H42O9P1"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_2agpg180_c" name="2_Acyl_sn_glycero_3_phosphoglycerol_n_C180" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C24H48O9P1"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_2agpg181_c" name="2_Acyl_sn_glycero_3_phosphoglycerol_n_C181" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C24H46O9P1"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_2dda7p_c" name="2_Dehydro_3_deoxy_D_arabino_heptonate_7_phosphate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C7H10O10P"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_2ddecg3p_c" name="2_dodecanoyl_sn_glycerol_3_phosphate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C15H30O7P1"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_2dmmql8_c" name="2_Demethylmenaquinol_8" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C50H72O2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_2dr1p_c" name="2_Deoxy_D_ribose_1_phosphate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C5H9O7P"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_2dr5p_c" name="2_Deoxy_D_ribose_5_phosphate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C5H9O7P"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_2hdec9eg3p_c" name="2_hexadec_9_enoyl_sn_glycerol_3_phosphate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C19H36O7P1"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_2hdecg3p_c" name="2_hexadecanoyl_sn_glycerol_3_phosphate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C19H38O7P1"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_2mahmp_c" name="2_Methyl_4_amino_5_hydroxymethylpyrimidine_diphosphate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C6H8N3O7P2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_2mbcoa_m" name="2-Methylbutanoyl-CoA" compartment="mitochondria" fbc:charge="0" fbc:chemicalFormula="C26H40N7O17P3S"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_2me4p_ap" name="2_C_methyl_D_erythritol_4_phosphate" compartment="apicoplast" fbc:charge="0" fbc:chemicalFormula="C5H11O7P"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_2mecdp_ap" name="2_C_methyl_D_erythritol_2_4_cyclodiphosphate" compartment="apicoplast" fbc:charge="0" fbc:chemicalFormula="C5H10O9P2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_2odec11eg3p_c" name="2_octadec_11_enoyl_sn_glycerol_3_phosphate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C21H40O7P1"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_2odecg3p_c" name="2_octadecanoyl_sn_glycerol_3_phosphate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C21H42O7P1"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_2ohph_m" name="2_Octaprenyl_6_hydroxyphenol" compartment="mitochondria" fbc:charge="0" fbc:chemicalFormula="C46H70O2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_2ombzl_m" name="2_Octaprenyl_6_methoxy_1_4_benzoquinol" compartment="mitochondria" fbc:charge="0" fbc:chemicalFormula="C47H72O3"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_2omhmbl_m" name="2_Octaprenyl_3_methyl_5_hydroxy_6_methoxy_1_4_benzoquinol" compartment="mitochondria" fbc:charge="0" fbc:chemicalFormula="C48H74O4"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_2ommbl_m" name="2_Octaprenyl_3_methyl_6_methoxy_1_4_benzoquinol" compartment="mitochondria" fbc:charge="0" fbc:chemicalFormula="C48H74O3"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_2omph_m" name="2_Octaprenyl_6_methoxyphenol" compartment="mitochondria" fbc:charge="0" fbc:chemicalFormula="C47H72O2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_2oph_m" name="2_Octaprenylphenol" compartment="mitochondria" fbc:charge="0" fbc:chemicalFormula="C46H70O"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_2p4c2me_ap" name="2_phospho_4_cytidine_5_diphospho_2_C_methyl_D_erythritol" compartment="apicoplast" fbc:charge="0" fbc:chemicalFormula="C14H22N3O17P3"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_2pg_c" name="D_Glycerate_2_phosphate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C3H4O7P"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_2tdec7eg3p_c" name="2_tetradec_7_enoyl_sn_glycerol_3_phosphate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C17H32O7P1"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_2tdecg3p_c" name="2_tetradecanoyl_sn_glycerol_3_phosphate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C17H34O7P1"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_35ccmp_c" name="3_5_Cyclic_CMP" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C9H11N3O7P"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_35cdamp_c" name="3_5_Cyclic_dAMP" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C10H11N5O5P"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_35cgmp_c" name="3_5_Cyclic_GMP" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C10H11N5O7P"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_35cgmp_e" name="3_5_Cyclic_GMP" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="C10H11N5O7P"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_35cimp_c" name="3_5_Cyclic_IMP" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C10H10N4O7P"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_3dhq_c" name="3_Dehydroquinate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C7H9O6"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_3dhsk_c" name="3_Dehydroshikimate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C7H7O5"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_3dsphgn_c" name="3_Dehydrosphinganine" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C18H38NO2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_3haACP_ap" name="3R_3_Hydroxyacyl_acyl_carrier_protein" compartment="apicoplast" fbc:charge="0" fbc:chemicalFormula="C15H27N2O9PRS"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_3hcddec5eACP_ap" name="R_3_hydroxy_cis_dodec_5_enoyl_acyl_carrier_protein" compartment="apicoplast" fbc:charge="0" fbc:chemicalFormula="C23H41N2O9PRS"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_3hcmrs7eACP_ap" name="R_3_hydroxy_cis_myristol_7_eoyl_acyl_carrier_protein" compartment="apicoplast" fbc:charge="0" fbc:chemicalFormula="C25H45N2O9PRS"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_3hcpalm9eACP_ap" name="R_3_hydroxy_cis_palm_9_eoyl_acyl_carrier_protein" compartment="apicoplast" fbc:charge="0" fbc:chemicalFormula="C27H49N2O9PRS"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_3hcvac11eACP_ap" name="R_3_hydroxy_cis_vacc_11_enoyl_acyl_carrier_protein" compartment="apicoplast" fbc:charge="0" fbc:chemicalFormula="C29H53N2O9PRS"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_3hddecACP_ap" name="R_3_Hydroxydodecanoyl_acyl_carrier_protein" compartment="apicoplast" fbc:charge="0" fbc:chemicalFormula="C23H43N2O9PRS"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_3hdecACP_ap" name="R_3_Hydroxydecanoyl_acyl_carrier_protein" compartment="apicoplast" fbc:charge="0" fbc:chemicalFormula="C21H39N2O9PRS"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_3hhexACP_ap" name="R_3_Hydroxyhexanoyl_acyl_carrier_protein" compartment="apicoplast" fbc:charge="0" fbc:chemicalFormula="C17H31N2O9PRS"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_3hmp_c" name="3-Hydroxy-2-methylpropanoate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C4H7O3"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_3hmrsACP_ap" name="R_3_Hydroxytetradecanoyl_acyl_carrier_protein" compartment="apicoplast" fbc:charge="0" fbc:chemicalFormula="C25H47N2O9PRS"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_3hoctACP_ap" name="R_3_Hydroxyoctanoyl_acyl_carrier_protein" compartment="apicoplast" fbc:charge="0" fbc:chemicalFormula="C19H35N2O9PRS"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_3hoctaACP_ap" name="R_3_Hydroxyoctadecanoyl_acyl_carrier_protein" compartment="apicoplast" fbc:charge="0" fbc:chemicalFormula="C29H55N2O9PRS"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_3hpalmACP_ap" name="R_3_hydroxypalmitoyl_acyl_carrier_protein" compartment="apicoplast" fbc:charge="0" fbc:chemicalFormula="C27H51N2O9PRS"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_3mob_c" name="3_Methyl_2_oxobutanoate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C5H7O3"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_3mob_m" name="3_Methyl_2_oxobutanoate" compartment="mitochondria" fbc:charge="0" fbc:chemicalFormula="C5H7O3"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_3mop_c" name="S_3_Methyl_2_oxopentanoate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C6H9O3"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_3mop_m" name="S_3_Methyl_2_oxopentanoate" compartment="mitochondria" fbc:charge="0" fbc:chemicalFormula="C6H9O3"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_3ocddec5eACP_ap" name="3_oxo_cis_dodec_5_enoyl_acyl_carrier_protein" compartment="apicoplast" fbc:charge="0" fbc:chemicalFormula="C23H39N2O9PRS"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_3ocmrs7eACP_ap" name="3_oxo_cis_myristol_7_eoyl_acyl_carrier_protein" compartment="apicoplast" fbc:charge="0" fbc:chemicalFormula="C25H43N2O9PRS"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_3ocpalm9eACP_ap" name="3_oxo_cis_palm_9_eoyl_acyl_carrier_protein" compartment="apicoplast" fbc:charge="0" fbc:chemicalFormula="C27H47N2O9PRS"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_3ocvac11eACP_ap" name="3_oxo_cis_vacc_11_enoyl_acyl_carrier_protein" compartment="apicoplast" fbc:charge="0" fbc:chemicalFormula="C29H51N2O9PRS"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_3odcoa_c" name="3_Oxodecanoyl_CoA" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C31H48N7O18P3S"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_3oddcoa_c" name="3_Oxododecanoyl_CoA" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C33H52N7O18P3S"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_3oddecACP_ap" name="3_Oxododecanoyl_acyl_carrier_protein" compartment="apicoplast" fbc:charge="0" fbc:chemicalFormula="C23H41N2O9PRS"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_3odecACP_ap" name="3_Oxodecanoyl_acyl_carrier_protein" compartment="apicoplast" fbc:charge="0" fbc:chemicalFormula="C21H37N2O9PRS"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_3ohcoa_c" name="3_Oxohexanoyl_CoA" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C27H40N7O18P3S"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_3ohdcoa_c" name="3_Oxohexadecanoyl_CoA" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C37H60N7O18P3S"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_3ohexACP_ap" name="3_Oxohexanoyl_acyl_carrier_protein" compartment="apicoplast" fbc:charge="0" fbc:chemicalFormula="C17H29N2O9PRS"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_3omrsACP_ap" name="3_Oxotetradecanoyl_acyl_carrier_protein" compartment="apicoplast" fbc:charge="0" fbc:chemicalFormula="C25H45N2O9PRS"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_3oocoa_c" name="3_Oxooctanoyl_CoA" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C29H44N7O18P3S"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_3ooctACP_ap" name="3_Oxooctanoyl_acyl_carrier_protein" compartment="apicoplast" fbc:charge="0" fbc:chemicalFormula="C19H33N2O9PRS"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_3ooctdACP_ap" name="3_Oxooctadecanoyl_acyl_carrier_protein" compartment="apicoplast" fbc:charge="0" fbc:chemicalFormula="C29H53N2O9PRS"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_3ohodcoa_c" name="3_Oxooctadecanoyl_CoA" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C39H64N7O18P3S"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_3opalmACP_ap" name="3_Oxohexadecanoyl_acyl_carrier_protein" compartment="apicoplast" fbc:charge="0" fbc:chemicalFormula="C27H49N2O9PRS"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_3ophb_m" name="3_Octaprenyl_4_hydroxybenzoate" compartment="mitochondria" fbc:charge="0" fbc:chemicalFormula="C47H69O3"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_3otdcoa_c" name="3_Oxotetradecanoyl_CoA" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C35H56N7O18P3S"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_3pg_c" name="3_Phospho_D_glycerate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C3H4O7P"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_3psme_c" name="5_O_1_Carboxyvinyl_3_phosphoshikimate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C10H9O10P"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_4abut_c" name="4_Aminobutanoate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C4H9NO2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_4abut_e" name="4_Aminobutanoate" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="C4H9NO2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_4abz_c" name="4_Aminobenzoate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C7H6NO2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_4abz_e" name="4_Aminobenzoate" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="C7H6NO2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_4adcho_c" name="4_amino_4_deoxychorismate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C10H10NO5"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_4ahmmp_c" name="4_Amino_5_hydroxymethyl_2_methylpyrimidine" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C6H9N3O"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_4ahmmp_e" name="4_Amino_5_hydroxymethyl_2_methylpyrimidine" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="C6H9N3O"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_4ampm_c" name="4_Amino_2_methyl_5_phosphomethylpyrimidine" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C6H8N3O4P"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_4c2me_ap" name="4_cytidine_5_diphospho_2_C_methyl_D_erythritol" compartment="apicoplast" fbc:charge="0" fbc:chemicalFormula="C14H23N3O14P2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_4hba_c" name="4_Hydroxy_benzyl_alcohol" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C7H8O2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_4hba_m" name="4_Hydroxy_benzyl_alcohol" compartment="mitochondria" fbc:charge="0" fbc:chemicalFormula="C7H8O2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_4hbz_c" name="4_Hydroxybenzoate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C7H5O3"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_4hbz_m" name="4_Hydroxybenzoate" compartment="mitochondria" fbc:charge="0" fbc:chemicalFormula="C7H5O3"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_4mhetz_c" name="4_Methyl_5_2_hydroxyethyl_thiazole" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C6H9NOS"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_4mhetz_m" name="4_Methyl_5_2_hydroxyethyl_thiazole" compartment="mitochondria" fbc:charge="0" fbc:chemicalFormula="C6H9NOS"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_4mop_c" name="4_Methyl_2_oxopentanoate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C6H9O3"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_4mop_m" name="4_Methyl_2_oxopentanoate" compartment="mitochondria" fbc:charge="0" fbc:chemicalFormula="C6H9O3"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_4mpetz_c" name="4_Methyl_5_2_phosphoethyl_thiazole" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C6H8NO4PS"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_4mpetz_m" name="4_Methyl_5_2_phosphoethyl_thiazole" compartment="mitochondria" fbc:charge="0" fbc:chemicalFormula="C6H8NO4PS"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_4ppan_c" name="D_4_Phosphopantothenate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C9H15NO8P"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_4ppcys_c" name="N_R_4_Phosphopantothenoyl_L_cysteine" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C12H20N2O9PS"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_5aop_ap" name="5_Amino_4_oxopentanoate" compartment="apicoplast" fbc:charge="0" fbc:chemicalFormula="C5H9NO3"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_5aop_c" name="5_Amino_4_oxopentanoate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C5H9NO3"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_5aop_m" name="5_Amino_4_oxopentanoate" compartment="mitochondria" fbc:charge="0" fbc:chemicalFormula="C5H9NO3"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_5mta_c" name="5_Methylthioadenosine" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C11H15N5O3S"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_5mti_c" name="5-methyl thioinosine" compartment="cytosol" fbc:charge="0.0" fbc:chemicalFormula="C11H14N4O4S"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_5mtr1p_c" name="5_methylthio_d_ribose_1_phosphate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C6H13O7PS"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_6hmhpt_c" name="6_hydroxymethyl_dihydropterin" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C7H9N5O2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_6hmhpt_e" name="6_hydroxymethyl_dihydropterin" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="C7H9N5O2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_6hmhptpp_c" name="6_hydroxymethyl_dihydropterin_pyrophosphate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C7H8N5O8P2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_6pgc_c" name="6_Phospho_D_gluconate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C6H10O10P"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_6pgl_c" name="6_phospho_D_glucono_1_5_lactone" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C6H9O9P"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_6pthp_c" name="6-Pyruvoyl-5,6,7,8-tetrahydropterin" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C9H11N5O3"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ACP_ap" name="acyl_carrier_protein" compartment="apicoplast" fbc:charge="0" fbc:chemicalFormula="C11H21N2O7PRS"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_Asn_X_Ser_Thr_c" name="rotein-linke" compartment="cytosol" fbc:charge="0"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_cysi__L_c" name="L-Cystine" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C6H12N2O4S2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_cysi__L_e" name="L-Cystine" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="C6H12N2O4S2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_Rtotal_c" name="Lipid" compartment="cytosol" fbc:charge="0"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_Rtotal_e" name="Lipid" compartment="extracellular" fbc:charge="0"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_Rtotalcoa_c" name="LipidCoa" compartment="cytosol" fbc:charge="0"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_Rtotalcoa_e" name="LipidCoa" compartment="extracellular" fbc:charge="0"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_aacoa_c" name="Acetoacetyl_CoA" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C25H36N7O18P3S"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ac_c" name="Acetate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C2H3O2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ac_e" name="Acetate" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="C2H3O2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_acald_c" name="Acetaldehyde" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C2H4O"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_acald_e" name="Acetaldehyde" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="C2H4O"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_accoa_ap" name="Acetyl_CoA" compartment="apicoplast" fbc:charge="0" fbc:chemicalFormula="C23H34N7O17P3S"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_accoa_c" name="Acetyl_CoA" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C23H34N7O17P3S"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_accoa_m" name="Acetyl_CoA" compartment="mitochondria" fbc:charge="0" fbc:chemicalFormula="C23H34N7O17P3S"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_acgam1p_c" name="N_Acetyl_D_glucosamine_1_phosphate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C8H14NO9P"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_acgam6p_c" name="N_Acetyl_D_glucosamine_6_phosphate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C8H14NO9P"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_acglu_c" name="N_Acetyl_L_glutamate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C7H9NO5"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_acgpail_c" name="N-Acetyl-D-glucosaminylphosphatidylinositol" compartment="cytosol" fbc:charge="[]" fbc:chemicalFormula="[]"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_acon_C_c" name="cis_Aconitate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C6H3O6"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_acon_C_m" name="cis_Aconitate" compartment="mitochondria" fbc:charge="0" fbc:chemicalFormula="C6H3O6"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_actACP_ap" name="Acetoacetyl_ACP" compartment="apicoplast" fbc:charge="0" fbc:chemicalFormula="C15H25N2O9PRS"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ade_c" name="Adenine" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C5H5N5"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ade_e" name="Adenine" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="C5H5N5"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_adn_c" name="Adenosine" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C10H13N5O4"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_adn_e" name="Adenosine" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="C10H13N5O4"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_adp_ap" name="ADP" compartment="apicoplast" fbc:charge="0" fbc:chemicalFormula="C10H12N5O10P2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_adp_c" name="ADP" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C10H12N5O10P2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_adp_m" name="ADP" compartment="mitochondria" fbc:charge="0" fbc:chemicalFormula="C10H12N5O10P2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ahcys_c" name="S_Adenosyl_L_homocysteine" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C14H20N6O5S"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ahcys_m" name="S_Adenosyl_L_homocysteine" compartment="mitochondria" fbc:charge="0" fbc:chemicalFormula="C14H20N6O5S"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ahdt_c" name="2_Amino_4_hydroxy_6_erythro_1_2_3_trihydroxypropyl_dihydropteridine_triphosphate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C9H12N5O13P3"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_aicar_c" name="5_Amino_1_5_Phospho_D_ribosyl_imidazole_4_carboxamide" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C9H13N4O8P"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_akg_c" name="2_Oxoglutarate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C5H4O5"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_akg_e" name="2_Oxoglutarate" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="C5H4O5"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_akg_m" name="2_Oxoglutarate" compartment="mitochondria" fbc:charge="0" fbc:chemicalFormula="C5H4O5"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ala__L_c" name="L_Alanine" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C3H7NO2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ala__L_e" name="L_Alanine" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="C3H7NO2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ala__L_m" name="L_Alanine" compartment="mitochondria" fbc:charge="0" fbc:chemicalFormula="C3H7NO2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_alatrna_c" name="L_Alanyl_tRNA_Ala" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C3H6NOR"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_amet_c" name="S_Adenosyl_L_methionine" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C15H23N6O5S"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_amet_e" name="S_Adenosyl_L_methionine" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="C15H23N6O5S"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_amet_m" name="S_Adenosyl_L_methionine" compartment="mitochondria" fbc:charge="0" fbc:chemicalFormula="C15H23N6O5S"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ametam_c" name="S_Adenosylmethioninamine" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C14H24N6O3S"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_amp_ap" name="AMP" compartment="apicoplast" fbc:charge="0" fbc:chemicalFormula="C10H12N5O7P"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_amp_c" name="AMP" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C10H12N5O7P"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_anth_c" name="Anthranilate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C7H6NO2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_apg120_c" name="acyl_phosphatidylglycerol_n_C120" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C42H80O11P"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_apg140_c" name="acyl_phosphatidylglycerol_n_C140" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C48H92O11P"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_apg141_c" name="acyl_phosphatidylglycerol_n_C141" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C48H86O11P"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_apg160_c" name="acyl_phosphatidylglycerol_n_C160" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C54H104O11P"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_apg161_c" name="acyl_phosphatidylglycerol_n_C161" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C54H98O11P"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_apg180_c" name="acyl_phosphatidylglycerol_n_C180" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C60H116O11P"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_apg181_c" name="acyl_phosphatidylglycerol_n_C181" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C60H110O11P"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_apoACP_c" name="apoprotein_acyl_carrier_protein" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="RHO"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_arg__L_c" name="L_Arginine" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C6H15N4O2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_arg__L_e" name="L_Arginine" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="C6H15N4O2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_asn__L_c" name="L_Asparagine" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C4H8N2O3"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_asn__L_e" name="L_Asparagine" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="C4H8N2O3"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_asp__L_c" name="L_Aspartate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C4H6NO4"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_asp__L_e" name="L_Aspartate" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="C4H6NO4"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_asp__L_m" name="L_Aspartate" compartment="mitochondria" fbc:charge="0" fbc:chemicalFormula="C4H6NO4"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_atp_ap" name="ATP" compartment="apicoplast" fbc:charge="0" fbc:chemicalFormula="C10H12N5O13P3"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_atp_c" name="ATP" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C10H12N5O13P3"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_atp_m" name="ATP" compartment="mitochondria" fbc:charge="0" fbc:chemicalFormula="C10H12N5O13P3"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_btcoa_c" name="Butanoyl_CoA" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C25H38N7O17P3S"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_but2eACP_ap" name="But_2_enoyl_acyl_carrier_protein" compartment="apicoplast" fbc:charge="0" fbc:chemicalFormula="C15H25N2O8PRS"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_butACP_ap" name="Butyryl_ACP_n_C40ACP" compartment="apicoplast" fbc:charge="0" fbc:chemicalFormula="C15H27N2O8PRS"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_camp_c" name="cAMP" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C10H11N5O6P"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_camp_e" name="cAMP" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="C10H11N5O6P"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_cbasp_c" name="N_Carbamoyl_L_aspartate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C5H6N2O5"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_cbp_c" name="Carbamoyl_phosphate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="CH2NO5P"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_cddec5eACP_ap" name="cis_dodec_5_enoyl_acyl_carrier_protein_n_C121" compartment="apicoplast" fbc:charge="0" fbc:chemicalFormula="C23H41N2O8PRS"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_cdec3eACP_ap" name="cis_dec_3_enoyl_acyl_carrier_protein_n_C101" compartment="apicoplast" fbc:charge="0" fbc:chemicalFormula="C21H37N2O8PRS"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_cdp_c" name="CDP" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C9H12N3O11P2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_cdpchol_c" name="CDPcholine" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C14H25N4O11P2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_cdpdag_c" name="CDP-Diacylglycerol" compartment="cytosol" fbc:charge="[]" fbc:chemicalFormula="[]"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_cdpdag_e" name="CDP-Diacylglycerol" compartment="extracellular" fbc:charge="[]" fbc:chemicalFormula="[]"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_cdpdddecg_c" name="CDP_1_2_didodecanoylglycerol" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C36H63N3O15P2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_cdpdddecg_e" name="CDP_1_2_didodecanoylglycerol" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="C36H63N3O15P2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_cdpdhdec9eg_c" name="CDP_1_2_dihexadec_9_enoylglycerol" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C44H75N3O15P2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_cdpdhdec9eg_e" name="CDP_1_2_dihexadec_9_enoylglycerol" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="C44H75N3O15P2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_cdpdhdecg_c" name="CDP_1_2_dihexadecanoylglycerol" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C44H79N3O15P2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_cdpdhdecg_e" name="CDP_1_2_dihexadecanoylglycerol" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="C44H79N3O15P2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_cdpdodec11eg_c" name="CDP_1_2_dioctadec_11_enoylglycerol" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C48H83N3O15P2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_cdpdodec11eg_e" name="CDP_1_2_dioctadec_11_enoylglycerol" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="C48H83N3O15P2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_cdpdodecg_c" name="CDP_1_2_dioctadecanoylglycerol" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C48H87N3O15P2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_cdpdodecg_e" name="CDP_1_2_dioctadecanoylglycerol" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="C48H87N3O15P2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_cdpdtdec7eg_c" name="CDP_1_2_ditetradec_7_enoylglycerol" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C40H67N3O15P2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_cdpdtdec7eg_e" name="CDP_1_2_ditetradec_7_enoylglycerol" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="C40H67N3O15P2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_cdpdtdecg_c" name="CDP_1_2_ditetradecanoylglycerol" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C40H71N3O15P2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_cdpdtdecg_e" name="CDP_1_2_ditetradecanoylglycerol" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="C40H71N3O15P2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_cdpea_c" name="CDPethanolamine" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C11H19N4O11P2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_chol_c" name="Choline" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C5H14NO"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_chol_e" name="Choline" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="C5H14NO"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_cholp_c" name="Choline_phosphate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C5H13NO4P"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_chor_c" name="chorismate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C10H8O6"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_chsterol_c" name="holesterol" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C27H46O"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_chsterol_e" name="holesterol" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="C27H46O"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_cit_c" name="Citrate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C6H5O7"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_cit_e" name="Citrate" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="C6H5O7"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_cit_m" name="Citrate" compartment="mitochondria" fbc:charge="0" fbc:chemicalFormula="C6H5O7"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_clpn120_c" name="cardiolipin_tetradodecanoyl_n_C120" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C57H108O17P2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_clpn140_c" name="cardiolipin_tetratetradecanoyl_n_C140" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C65H124O17P2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_clpn141_c" name="cardiolipin_tetratetradec_7_enoyl_n_C141" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C65H116O17P2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_clpn160_c" name="cardiolipin_tetrahexadecanoyl_n_C160" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C73H140O17P2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_clpn161_c" name="cardiolipin_tetrahexadec_9_enoyl_n_C161" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C73H132O17P2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_clpn180_c" name="cardiolipin_tetraoctadecanoyl_n_C180" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C81H156O17P2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_clpn181_c" name="cardiolipin_tetraoctadec_11_enoyl_n_C181" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C81H148O17P2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_cmp_ap" name="CMP" compartment="apicoplast" fbc:charge="0" fbc:chemicalFormula="C9H12N3O8P"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_cmp_c" name="CMP" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C9H12N3O8P"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_co2_ap" name="CO2" compartment="apicoplast" fbc:charge="0" fbc:chemicalFormula="CO2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_co2_c" name="CO2" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="CO2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_co2_e" name="CO2" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="CO2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_co2_m" name="CO2" compartment="mitochondria" fbc:charge="0" fbc:chemicalFormula="CO2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_coa_ap" name="Coenzyme_A" compartment="apicoplast" fbc:charge="0" fbc:chemicalFormula="C21H32N7O16P3S"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_coa_c" name="Coenzyme_A" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C21H32N7O16P3S"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_coa_m" name="Coenzyme_A" compartment="mitochondria" fbc:charge="0" fbc:chemicalFormula="C21H32N7O16P3S"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_cpppg3_ap" name="Coproporphyrinogen_III" compartment="apicoplast" fbc:charge="0" fbc:chemicalFormula="C36H40N4O8"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_cpppg3_c" name="Coproporphyrinogen_III" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C36H40N4O8"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_cpppg3_m" name="Coproporphyrinogen_III" compartment="mitochondria" fbc:charge="0" fbc:chemicalFormula="C36H40N4O8"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_crm_c" name="ceramide" compartment="cytosol" fbc:charge="[0]" fbc:chemicalFormula="['C18H36NO2RCO']"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ctp_ap" name="CTP" compartment="apicoplast" fbc:charge="0" fbc:chemicalFormula="C9H12N3O14P3"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ctp_c" name="CTP" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C9H12N3O14P3"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_cys__L_c" name="L_Cysteine" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C3H7NO2S"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_cys__L_e" name="L_Cysteine" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="C3H7NO2S"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_cys__L_m" name="L_Cysteine" compartment="mitochondria" fbc:charge="0" fbc:chemicalFormula="C3H7NO2S"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_cystrna_c" name="L_Cysteinyl_tRNA_Cys" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C3H6NOSR"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_dad_2_c" name="Deoxyadenosine" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C10H13N5O3"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_dad_2_e" name="Deoxyadenosine" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="C10H13N5O3"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_dadp_c" name="dADP" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C10H12N5O9P2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_dag_c" name="diacylglycerols (total)" compartment="cytosol" fbc:charge="[]" fbc:chemicalFormula="[]"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_dag_e" name="diacylglycerols (total)" compartment="extracellular" fbc:charge="[]" fbc:chemicalFormula="[]"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_damp_c" name="dAMP" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C10H12N5O6P"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_datp_c" name="dATP" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C10H12N5O12P3"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_dcaACP_ap" name="Decanoyl_ACP_n_C100ACP" compartment="apicoplast" fbc:charge="0" fbc:chemicalFormula="C21H39N2O8PRS"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_dca_ap" name="Decanoate_n_C100" compartment="apicoplast" fbc:charge="0" fbc:chemicalFormula="C10H19O2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_dca_c" name="Decanoate_n_C100" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C10H19O2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_dca_e" name="Decanoate_n_C100" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="C10H19O2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_dcacoa_ap" name="Decanoyl_CoA_n_C100CoA" compartment="apicoplast" fbc:charge="0" fbc:chemicalFormula="C31H50N7O17P3S"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_dcacoa_c" name="Decanoyl_CoA_n_C100CoA" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C31H50N7O17P3S"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_dcacoa_e" name="Decanoyl_CoA_n_C100CoA" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="C31H50N7O17P3S"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_dcamp_c" name="N6_1_2_Dicarboxyethyl_AMP" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C14H14N5O11P"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_dcdp_c" name="dCDP" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C9H12N3O10P2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_dctp_c" name="dCTP" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C9H12N3O13P3"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ddcaACP_ap" name="Dodecanoyl_ACP_n_C120ACP" compartment="apicoplast" fbc:charge="0" fbc:chemicalFormula="C23H43N2O8PRS"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ddca_ap" name="Dodecanoate_n_C120" compartment="apicoplast" fbc:charge="0" fbc:chemicalFormula="C12H23O2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ddca_c" name="Dodecanoate_n_C120" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C12H23O2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ddca_e" name="Dodecanoate_n_C120" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="C12H23O2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ddcacoa_ap" name="Dodecanoyl_CoA_n_C120CoA" compartment="apicoplast" fbc:charge="0" fbc:chemicalFormula="C33H54N7O17P3S"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ddcacoa_c" name="Dodecanoyl_CoA_n_C120CoA" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C33H54N7O17P3S"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ddcacoa_e" name="Dodecanoyl_CoA_n_C120CoA" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="C33H54N7O17P3S"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_dgdp_c" name="dGDP" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C10H12N5O10P2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_dgmp_c" name="dGMP" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C10H12N5O7P"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_dgsn_c" name="Deoxyguanosine" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C10H13N5O4"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_dgsn_e" name="Deoxyguanosine" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="C10H13N5O4"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_dgtp_c" name="dGTP" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C10H12N5O13P3"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_dhap_ap" name="Dihydroxyacetone_phosphate" compartment="apicoplast" fbc:charge="0" fbc:chemicalFormula="C3H5O6P"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_dhap_c" name="Dihydroxyacetone_phosphate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C3H5O6P"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_dhap_m" name="Dihydroxyacetone_phosphate" compartment="mitochondria" fbc:charge="0" fbc:chemicalFormula="C3H5O6P"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_dhcrm_c" name="Dihydroceramide" compartment="cytosol" fbc:charge="[0]" fbc:chemicalFormula="['C18H38NO2RCO']"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_dhf_c" name="7_8_Dihydrofolate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C19H19N7O6"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_dhnpt_c" name="Dihydroneopterin" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C9H13N5O4"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_dhor__S_c" name="S_Dihydroorotate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C5H5N2O4"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_dhor__S_m" name="S_Dihydroorotate" compartment="mitochondria" fbc:charge="0" fbc:chemicalFormula="C5H5N2O4"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_dhpt_c" name="Dihydropteroate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C14H13N6O3"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_dimp_c" name="dIMP" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C10H11N4O7P"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_din_c" name="Deoxyinosine" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C10H12N4O4"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_din_e" name="Deoxyinosine" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="C10H12N4O4"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ditp_c" name="dITP" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C10H11N4O13P3"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_dmpp_ap" name="Dimethylallyl_diphosphate" compartment="apicoplast" fbc:charge="0" fbc:chemicalFormula="C5H9O7P2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_dmpp_c" name="Dimethylallyl_diphosphate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C5H9O7P2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_dnad_c" name="Deamino_NAD" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C21H24N6O15P2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_doldp__L_c" name="Dolichol diphosphate" compartment="cytosol" fbc:charge="0"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_dolichol_c" name="Dolichol" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C15H28O"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_dolmanp__L_c" name="Dolichyl phosphate D-mannose" compartment="cytosol" fbc:charge="0"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_dolp_c" name="Dolichol_phosphate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C15H27O4P"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_dpcoa_ap" name="Dephospho_CoA" compartment="apicoplast" fbc:charge="0" fbc:chemicalFormula="C21H33N7O13P2S"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_dpcoa_c" name="Dephospho_CoA" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C21H33N7O13P2S"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_dsbaox_e" name="periplasmic_protein_disulfide_isomerase_I_oxidized" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="X"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_dsbard_e" name="periplasmic_protein_disulfide_isomerase_I_reduced" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="XH2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_dsbcox_c" name="protein_disulfide_isomerase_II_oxidized" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="X"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_dsbcrd_c" name="protein_disulfide_isomerase_II_reduced" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="XH2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_dsbgox_c" name="periplasmic_disulfide_isomerasethiol_disulphide_oxidase_oxidized" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="X"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_dsbgrd_c" name="periplasmic_disulfide_isomerasethiol_disulphide_oxidase_reduced" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="XH2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_dtdp_c" name="dTDP" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C10H13N2O11P2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_dtmp_c" name="dTMP" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C10H13N2O8P"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_dttp_c" name="dTTP" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C10H13N2O14P3"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_dudp_c" name="dUDP" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C9H11N2O11P2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_dump_c" name="dUMP" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C9H11N2O8P"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_duri_c" name="Deoxyuridine" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C9H12N2O5"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_dutp_c" name="dUTP" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C9H11N2O14P3"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_dxyl5p_ap" name="1_deoxy_D_xylulose_5_phosphate" compartment="apicoplast" fbc:charge="0" fbc:chemicalFormula="C5H9O7P"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_dxyl5p_c" name="1_deoxy_D_xylulose_5_phosphate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C5H9O7P"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_dxyl5p_m" name="1_deoxy_D_xylulose_5_phosphate" compartment="mitochondria" fbc:charge="0" fbc:chemicalFormula="C5H9O7P"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_e4p_c" name="D_Erythrose_4_phosphate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C4H7O7P"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_etha_c" name="Ethanolamine" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C2H8NO"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_etha_e" name="Ethanolamine" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="C2H8NO"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ethamp_c" name="Ethanolamine_phosphate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C2H7NO4P"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_f6p_c" name="D_Fructose_6_phosphate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C6H11O9P"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_fad_c" name="Flavin_adenine_dinucleotide_oxidized" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C27H31N9O15P2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_fdp_c" name="D_Fructose_1_6_bisphosphate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C6H10O12P2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_fe2_ap" name="Fe2" compartment="apicoplast" fbc:charge="0" fbc:chemicalFormula="Fe"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_fe2_c" name="Fe2" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="Fe"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_fe2_e" name="Fe2" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="Fe"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_fe3_c" name="Fe3" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="Fe"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ficytc_m" name="Ferricytochrome_c" compartment="mitochondria" fbc:charge="0" fbc:chemicalFormula="C42H52FeN8O6S2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_fldox_ap" name="flavodoxin_oxidized" compartment="apicoplast" fbc:charge="0" fbc:chemicalFormula="X"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_fldrd_ap" name="flavodoxin_reduced" compartment="apicoplast" fbc:charge="0" fbc:chemicalFormula="XH2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_fmet_c" name="N_Formyl_L_methionine" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C6H10NO3S"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_fmettrna_c" name="N_Formylmethionyl_tRNA" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C6H9NO2SR"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_fmn_c" name="FMN" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C17H19N4O9P"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_focytc_m" name="Ferrocytochrome_c" compartment="mitochondria" fbc:charge="0" fbc:chemicalFormula="C42H53FeN8O6S2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_fol_e" name="olate" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="C19H18N7O6"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_for_c" name="Formate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="CH1O2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_for_e" name="Formate" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="CH1O2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_frdp_c" name="Farnesyl_diphosphate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C15H25O7P2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_fru_c" name="D_Fructose" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C6H12O6"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_fru_e" name="D_Fructose" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="C6H12O6"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_fum_c" name="Fumarate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C4H2O4"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_fum_e" name="Fumarate" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="C4H2O4"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_fum_m" name="Fumarate" compartment="mitochondria" fbc:charge="0" fbc:chemicalFormula="C4H2O4"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_g1p_c" name="D_Glucose_1_phosphate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C6H11O9P"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_g3m8masn_c" name="alpha-D-Glucosyl)3-(alpha-D-mannosyl)8-beta-D-mannosyl-diacetylchitobiosyl-L-asparagine" compartment="cytosol" fbc:charge="0"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_g3m8mpdol__L_c" name="alpha-D-Glucosyl)3-(alpha-D-mannosyl)8-beta-D-mannosyl-diacetylchitobiosyldiphosphodolichol" compartment="cytosol" fbc:charge="0"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_g3p_ap" name="Glyceraldehyde_3_phosphate" compartment="apicoplast" fbc:charge="0" fbc:chemicalFormula="C3H5O6P"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_g3p_c" name="Glyceraldehyde_3_phosphate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C3H5O6P"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_g3pc_c" name="sn_Glycero_3_phosphocholine" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C8H20NO6P"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_g3pe_c" name="sn_Glycero_3_phosphoethanolamine" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C5H14NO6P"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_g3pg_c" name="Glycerophosphoglycerol" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C6H14O8P"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_g3pi_c" name="sn_Glycero_3_phospho_1_inositol" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C9H18O11P"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_g3ps_c" name="Glycerophosphoserine" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C6H13NO8P"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_g6p_c" name="D_Glucose_6_phosphate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C6H11O9P"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_gacpail_c" name="Glucosaminyl-acylphosphatidylinositol" compartment="cytosol" fbc:charge="[0]" fbc:chemicalFormula="[]"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_gam6p_c" name="D_Glucosamine_6_phosphate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C6H13NO8P"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_gam6p_e" name="D_Glucosamine_6_phosphate" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="C6H13NO8P"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_gam_c" name="D_Glucosamine" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C6H14NO5"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_gam_e" name="D_Glucosamine" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="C6H14NO5"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_gchola_c" name="lycocholate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C26H43NO6"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_gchola_e" name="lycocholate" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="C26H43NO6"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_gdp_c" name="GDP" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C10H12N5O11P2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_gdp_m" name="GDP" compartment="mitochondria" fbc:charge="0" fbc:chemicalFormula="C10H12N5O11P2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_gdpddman_c" name="GDP_4_dehydro_6_deoxy_D_mannose" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C16H21N5O15P2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_gdpfuc_c" name="GDP_L_fucose" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C16H23N5O15P2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_gdpmann_c" name="GDP_D_mannose" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C16H23N5O16P2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ggdp_c" name="Geranylgeranyl diphosphate" compartment="cytosol" fbc:charge="0"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_glc__D_c" name="D_Glucose" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C6H12O6"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_glc__D_e" name="D_Glucose" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="C6H12O6"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_glcn_c" name="D_Gluconate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C6H11O7"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_gln__L_c" name="L_Glutamine" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C5H10N2O3"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_gln__L_e" name="L_Glutamine" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="C5H10N2O3"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_glu5sa_c" name="L_Glutamate_5_semialdehyde" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C5H9NO3"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_glu__L_c" name="L_Glutamate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C5H8NO4"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_glu__L_e" name="L_Glutamate" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="C5H8NO4"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_glu__L_m" name="L_Glutamate" compartment="mitochondria" fbc:charge="0" fbc:chemicalFormula="C5H8NO4"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_glucys_c" name="gamma_L_Glutamyl_L_cysteine" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C8H13N2O5S"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_gluside_c" name="D-glucosyl-N-acylsphingosine" compartment="cytosol" fbc:charge="[0]" fbc:chemicalFormula="[]"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_glutrna_c" name="L_Glutamyl_tRNA_Glu" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C5H7NO3R"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_gly_c" name="Glycine" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C2H5NO2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_gly_e" name="Glycine" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="C2H5NO2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_gly_m" name="Glycine" compartment="mitochondria" fbc:charge="0" fbc:chemicalFormula="C2H5NO2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_glyald_c" name="D_Glyceraldehyde" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C3H6O3"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_glyc3p_ap" name="Glycerol_3_phosphate" compartment="apicoplast" fbc:charge="0" fbc:chemicalFormula="C3H7O6P"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_glyc3p_c" name="Glycerol_3_phosphate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C3H7O6P"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_glyc3p_m" name="Glycerol_3_phosphate" compartment="mitochondria" fbc:charge="0" fbc:chemicalFormula="C3H7O6P"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_glyc_c" name="Glycerol" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C3H8O3"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_glyc_e" name="Glycerol" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="C3H8O3"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_gmp_c" name="GMP" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C10H12N5O8P"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_gpail_c" name="D-glucosaminylphosphatidylinositol" compartment="cytosol" fbc:charge="[0]" fbc:chemicalFormula="['C15H28NO13PRCO2R2CO2']"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_grdp_c" name="Geranyl_diphosphate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C10H17O7P2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_gsn_c" name="Guanosine" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C10H13N5O5"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_gsn_e" name="Guanosine" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="C10H13N5O5"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_gthox_c" name="Oxidized_glutathione" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C20H30N6O12S2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_gthox_e" name="Oxidized_glutathione" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="C20H30N6O12S2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_gthrd_c" name="Reduced_glutathione" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C10H16N3O6S"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_gthrd_e" name="Reduced_glutathione" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="C10H16N3O6S"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_gtp_c" name="GTP" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C10H12N5O14P3"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_gtp_m" name="GTP" compartment="mitochondria" fbc:charge="0" fbc:chemicalFormula="C10H12N5O14P3"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_gua_c" name="Guanine" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C5H5N5O"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_gua_e" name="Guanine" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="C5H5N5O"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_h2mb4p_ap" name="1_hydroxy_2_methyl_2_E_butenyl_4_diphosphate" compartment="apicoplast" fbc:charge="0" fbc:chemicalFormula="C5H9O8P2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_h2o2_c" name="Hydrogen_peroxide" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="H2O2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_h2o2_e" name="Hydrogen_peroxide" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="H2O2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_h2o2_m" name="Hydrogen_peroxide" compartment="mitochondria" fbc:charge="0" fbc:chemicalFormula="H2O2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_h2o_ap" name="H2O" compartment="apicoplast" fbc:charge="0" fbc:chemicalFormula="H2O"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_h2o_c" name="H2O" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="H2O"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_h2o_e" name="H2O" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="H2O"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_h2o_m" name="H2O" compartment="mitochondria" fbc:charge="0" fbc:chemicalFormula="H2O"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_h_ap" name="H" compartment="apicoplast" fbc:charge="0" fbc:chemicalFormula="H"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_h_c" name="H" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="H"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_h_e" name="H" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="H"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_h_m" name="H" compartment="mitochondria" fbc:charge="0" fbc:chemicalFormula="H"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_hb_c" name="host hemoglobin" compartment="cytosol" fbc:charge="[]" fbc:chemicalFormula="[]"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_hb_e" name="host hemoglobin" compartment="extracellular" fbc:charge="[]" fbc:chemicalFormula="[]"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_hco3_ap" name="Bicarbonate" compartment="apicoplast" fbc:charge="0" fbc:chemicalFormula="CHO3"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_hco3_c" name="Bicarbonate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="CHO3"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_hco3_e" name="Bicarbonate" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="CHO3"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_hcys__L_c" name="L_Homocysteine" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C4H9NO2S"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_hcys__L_e" name="Homocysteine" compartment="extracellular" fbc:charge="0"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_hdca_ap" name="Hexadecanoate_n_C160" compartment="apicoplast" fbc:charge="0" fbc:chemicalFormula="C16H31O2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_hdca_c" name="Hexadecanoate_n_C160" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C16H31O2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_hdca_e" name="Hexadecanoate_n_C160" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="C16H31O2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_hdcea_ap" name="Hexadecenoate_n_C161" compartment="apicoplast" fbc:charge="0" fbc:chemicalFormula="C16H29O2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_hdcea_c" name="Hexadecenoate_n_C161" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C16H29O2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_hdcea_e" name="Hexadecenoate_n_C161" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="C16H29O2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_hdcoa_ap" name="Hexadecenoyl_CoA_n_C161CoA" compartment="apicoplast" fbc:charge="0" fbc:chemicalFormula="C37H60N7O17P3S"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_hdcoa_c" name="Hexadecenoyl_CoA_n_C161CoA" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C37H60N7O17P3S"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_hdcoa_e" name="Hexadecenoyl_CoA_n_C161CoA" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="C37H60N7O17P3S"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_hdeACP_ap" name="cis_hexadec_9_enoyl_acyl_carrier_protein_n_C161" compartment="apicoplast" fbc:charge="0" fbc:chemicalFormula="C27H49N2O8PRS"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_hepdp_m" name="all_trans_Heptaprenyl_diphosphate" compartment="mitochondria" fbc:charge="0" fbc:chemicalFormula="C35H57O7P2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_hexACP_ap" name="Hexanoyl_ACP_n_C60ACP" compartment="apicoplast" fbc:charge="0" fbc:chemicalFormula="C17H31N2O8PRS"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_hexc_ap" name="hexacosanoate_n_C260" compartment="apicoplast" fbc:charge="0" fbc:chemicalFormula="C26H51O2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_hexc_c" name="hexacosanoate_n_C260" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C26H51O2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_hexc_e" name="hexacosanoate_n_C260" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="C26H51O2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_hexdp_m" name="all_trans_Hexaprenyl_diphosphate" compartment="mitochondria" fbc:charge="0" fbc:chemicalFormula="C30H49O7P2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_hibcoa_c" name="S_3_Hydroxyisobutyryl_CoA" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C25H38N7O18P3S"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_his__L_c" name="L_Histidine" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C6H9N3O2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_his__L_e" name="L_Histidine" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="C6H9N3O2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_histrna_c" name="L_Histidyl_tRNA_His" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C6H8N3OR"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_hmbil_ap" name="Hydroxymethylbilane" compartment="apicoplast" fbc:charge="0" fbc:chemicalFormula="C40H38N4O17"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_hmbil_c" name="Hydroxymethylbilane" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C40H38N4O17"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_hxa_ap" name="Hexanoate_n_C60" compartment="apicoplast" fbc:charge="0" fbc:chemicalFormula="C6H11O2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_hxa_c" name="Hexanoate_n_C60" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C6H11O2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_hxa_e" name="Hexanoate_n_C60" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="C6H11O2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_hxan_c" name="Hypoxanthine" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C5H4N4O"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_hxan_e" name="Hypoxanthine" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="C5H4N4O"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_hxcoa_ap" name="Hexanoyl_CoA_n_C60CoA" compartment="apicoplast" fbc:charge="0" fbc:chemicalFormula="C27H42N7O17P3S"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_hxcoa_c" name="Hexanoyl_CoA_n_C60CoA" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C27H42N7O17P3S"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_hxcoa_e" name="Hexanoyl_CoA_n_C60CoA" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="C27H42N7O17P3S"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ibcoa_m" name="sobutyryl-CoA" compartment="mitochondria" fbc:charge="0" fbc:chemicalFormula="C25H38N7O17P3S"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_icit_c" name="Isocitrate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C6H5O7"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_icit_m" name="Isocitrate" compartment="mitochondria" fbc:charge="0" fbc:chemicalFormula="C6H5O7"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ile__L_c" name="L_Isoleucine" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C6H13NO2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ile__L_e" name="L_Isoleucine" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="C6H13NO2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_iletrna_c" name="L_Isoleucyl_tRNA_Ile" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C6H12NOR"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_imp_c" name="IMP" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C10H11N4O8P"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_inost_c" name="myo_Inositol" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C6H12O6"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_inost_e" name="myo_Inositol" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="C6H12O6"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ins_c" name="Inosine" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C10H12N4O5"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ins_e" name="Inosine" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="C10H12N4O5"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ipdp_ap" name="Isopentenyl_diphosphate" compartment="apicoplast" fbc:charge="0" fbc:chemicalFormula="C5H9O7P2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ipdp_c" name="Isopentenyl_diphosphate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C5H9O7P2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ipdp_m" name="Isopentenyl_diphosphate" compartment="mitochondria" fbc:charge="0" fbc:chemicalFormula="C5H9O7P2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_itp_c" name="ITP" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C10H11N4O14P3"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ivcoa_m" name="sovaleryl-CoA" compartment="mitochondria" fbc:charge="0" fbc:chemicalFormula="C26H40N7O17P3S"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_lac__D_c" name="D_Lactate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C3H5O3"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_lac__D_e" name="D_Lactate" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="C3H5O3"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_lac__L_c" name="L_Lactate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C3H5O3"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_leu__L_c" name="L_Leucine" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C6H13NO2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_leu__L_e" name="L_Leucine" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="C6H13NO2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_leutrna_c" name="L_Leucyl_tRNA_Leu" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C6H12NOR"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_lgt__S_c" name="R_S_Lactoylglutathione" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C13H20N3O8S"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_lpchol_c" name="Lysophosphatidylcholine" compartment="cytosol" fbc:charge="[0]" fbc:chemicalFormula="['C8H19NO5PRCO2']"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_lys__L_c" name="L_Lysine" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C6H15N2O2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_lys__L_e" name="L_Lysine" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="C6H15N2O2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_m5mpdol__L_c" name="alpha-D-Mannosyl)5-beta-D-mannosyl-diacetylchitobiosyldiphosphodolichol" compartment="cytosol" fbc:charge="0"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_m6mpdol__L_c" name="alpha-D-Mannosyl)6-beta-D-mannosyl-diacetylchitobiosyldiphosphodolichol" compartment="cytosol" fbc:charge="0"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_m7mpdol__L_c" name="alpha-D-Mannosyl)7-beta-D-mannosyl-diacetylchitobiosyldiphosphodolichol" compartment="cytosol" fbc:charge="0"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_malACP_ap" name="Malonyl_acyl_carrier_protein" compartment="apicoplast" fbc:charge="0" fbc:chemicalFormula="C14H22N2O10PRS"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_mal__L_c" name="L_Malate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C4H4O5"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_mal__L_e" name="L_Malate" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="C4H4O5"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_mal__L_m" name="L_Malate" compartment="mitochondria" fbc:charge="0" fbc:chemicalFormula="C4H4O5"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_malcoa_ap" name="Malonyl_CoA" compartment="apicoplast" fbc:charge="0" fbc:chemicalFormula="C24H33N7O19P3S"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_malt_c" name="Maltose" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C12H22O11"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_malt_e" name="Maltose" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="C12H22O11"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_man1p_c" name="D_Mannose_1_phosphate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C6H11O9P"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_man6p_c" name="D_Mannose_6_phosphate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C6H11O9P"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_man_c" name="D_Mannose" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C6H12O6"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_man_e" name="D_Mannose" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="C6H12O6"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_met__L_c" name="L_Methionine" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C5H11NO2S"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_met__L_e" name="L_Methionine" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="C5H11NO2S"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_methf_c" name="5_10_Methenyltetrahydrofolate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C20H20N7O6"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_mettrna_c" name="L_Methionyl_tRNA_Met" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C5H10NOSR"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_mi13456p_c" name="1D-myo-Inositol 1,3,4,5,6-pentakisphosphate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C6H7O21P5"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_mi1345p_c" name="1D-myo-Inositol 1,3,4,5-tetrakisphosphate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C6H8O18P4"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_mi134p_c" name="1D-myo-Inositol 1,3,4-trisphosphate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C6H9O15P3"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_mi1456p_c" name="1D-myo-Inositol 1,4,5,6-tetrakisphosphate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C6H8O18P4"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_mi145p_c" name="1D_myo_Inositol_1_4_5_trisphosphate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C6H9O15P3"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_mi14p_c" name="1D-myo-Inositol 1,4-bisphosphate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C6H10O12P2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_mi1p__D_c" name="1D_myo_Inositol_1_phosphate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C6H11O9P"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_mi34p_c" name="1D-myo-Inositol 3,4-bisphosphate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C6H10O12P2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_mi4p__D_c" name="1D-myo-Inositol 4-phosphate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C6H11O9P"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_mlthf_c" name="5_10_Methylenetetrahydrofolate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C20H21N7O6"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_mlthf_m" name="5_10_Methylenetetrahydrofolate" compartment="mitochondria" fbc:charge="0" fbc:chemicalFormula="C20H21N7O6"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_mql8_c" name="Menaquinol_8" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C51H74O2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_mthgxl_c" name="Methylglyoxal" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C3H4O2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_mthgxl_e" name="Methylglyoxal" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="C3H4O2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_myrsACP_ap" name="Myristoyl_ACP_n_C140ACP" compartment="apicoplast" fbc:charge="0" fbc:chemicalFormula="C25H47N2O8PRS"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_nac_c" name="Nicotinate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C6H4NO2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_nac_e" name="Nicotinate" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="C6H4NO2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_nad_ap" name="Nicotinamide_adenine_dinucleotide" compartment="apicoplast" fbc:charge="0" fbc:chemicalFormula="C21H26N7O14P2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_nad_c" name="Nicotinamide_adenine_dinucleotide" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C21H26N7O14P2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_nad_m" name="Nicotinamide_adenine_dinucleotide" compartment="mitochondria" fbc:charge="0" fbc:chemicalFormula="C21H26N7O14P2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_nadh_ap" name="Nicotinamide_adenine_dinucleotide_reduced" compartment="apicoplast" fbc:charge="0" fbc:chemicalFormula="C21H27N7O14P2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_nadh_c" name="Nicotinamide_adenine_dinucleotide_reduced" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C21H27N7O14P2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_nadh_m" name="Nicotinamide_adenine_dinucleotide_reduced" compartment="mitochondria" fbc:charge="0" fbc:chemicalFormula="C21H27N7O14P2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_nadp_ap" name="Nicotinamide_adenine_dinucleotide_phosphate" compartment="apicoplast" fbc:charge="0" fbc:chemicalFormula="C21H25N7O17P3"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_nadp_c" name="Nicotinamide_adenine_dinucleotide_phosphate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C21H25N7O17P3"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_nadp_m" name="Nicotinamide_adenine_dinucleotide_phosphate" compartment="mitochondria" fbc:charge="0" fbc:chemicalFormula="C21H25N7O17P3"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_nadph_ap" name="Nicotinamide_adenine_dinucleotide_phosphate_reduced" compartment="apicoplast" fbc:charge="0" fbc:chemicalFormula="C21H26N7O17P3"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_nadph_c" name="Nicotinamide_adenine_dinucleotide_phosphate_reduced" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C21H26N7O17P3"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_nadph_m" name="Nicotinamide_adenine_dinucleotide_phosphate_reduced" compartment="mitochondria" fbc:charge="0" fbc:chemicalFormula="C21H26N7O17P3"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ncam_c" name="Nicotinamide" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C6H6N2O"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ncam_e" name="Nicotinamide" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="C6H6N2O"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_nh4_ap" name="Ammonium" compartment="apicoplast" fbc:charge="0" fbc:chemicalFormula="H4N"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_nh4_c" name="Ammonium" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="H4N"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_nh4_e" name="Ammonium" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="H4N"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_nh4_m" name="Ammonium" compartment="mitochondria" fbc:charge="0" fbc:chemicalFormula="H4N"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_nicrnt_c" name="Nicotinate_D_ribonucleotide" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C11H12NO9P"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_no2_c" name="Nitrite" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="NO2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_no2_e" name="Nitrite" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="NO2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_no2_m" name="Nitrite" compartment="mitochondria" fbc:charge="0" fbc:chemicalFormula="NO2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_no3_c" name="Nitrate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="NO3"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_no3_e" name="Nitrate" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="NO3"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_no3_m" name="Nitrate" compartment="mitochondria" fbc:charge="0" fbc:chemicalFormula="NO3"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_no_e" name="Nitric_oxide" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="NO"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_o2_ap" name="O2" compartment="apicoplast" fbc:charge="0" fbc:chemicalFormula="O2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_o2_c" name="O2" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="O2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_o2_e" name="O2" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="O2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_o2_m" name="O2" compartment="mitochondria" fbc:charge="0" fbc:chemicalFormula="O2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_o2s_e" name="Superoxide_anion" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="O2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_oaa_c" name="Oxaloacetate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C4H2O5"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_oaa_m" name="Oxaloacetate" compartment="mitochondria" fbc:charge="0" fbc:chemicalFormula="C4H2O5"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ocACP_ap" name="Octanoyl_ACP_n_C80ACP" compartment="apicoplast" fbc:charge="0" fbc:chemicalFormula="C19H35N2O8PRS"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_occoa_ap" name="Octanoyl_CoA_n_C80CoA" compartment="apicoplast" fbc:charge="0" fbc:chemicalFormula="C29H46N7O17P3S"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_occoa_c" name="Octanoyl_CoA_n_C80CoA" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C29H46N7O17P3S"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_occoa_e" name="Octanoyl_CoA_n_C80CoA" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="C29H46N7O17P3S"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ocdcaACP_ap" name="Octadecanoyl_ACP_n_C180ACP" compartment="apicoplast" fbc:charge="0" fbc:chemicalFormula="C29H55N2O8PRS"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ocdca_ap" name="octadecanoate_n_C180" compartment="apicoplast" fbc:charge="0" fbc:chemicalFormula="C18H35O2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ocdca_c" name="octadecanoate_n_C180" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C18H35O2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ocdca_e" name="octadecanoate_n_C180" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="C18H35O2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ocdcea_ap" name="octadecenoate_n_C181" compartment="apicoplast" fbc:charge="0" fbc:chemicalFormula="C18H33O2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ocdcea_c" name="octadecenoate_n_C181" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C18H33O2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ocdcea_e" name="octadecenoate_n_C181" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="C18H33O2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ocdycacoa_c" name="Octadecynoyl_CoA_n_C182CoA" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C39H62N7O17P3S"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_octa_ap" name="octanoate_n_C80" compartment="apicoplast" fbc:charge="0" fbc:chemicalFormula="C8H15O2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_octa_c" name="octanoate_n_C80" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C8H15O2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_octa_e" name="octanoate_n_C80" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="C8H15O2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_octdp_c" name="all_trans_Octaprenyl_diphosphate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C40H65O7P2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_octdp_m" name="all_trans_Octaprenyl_diphosphate" compartment="mitochondria" fbc:charge="0" fbc:chemicalFormula="C40H65O7P2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_octeACP_ap" name="cis_octadec_11_enoyl_acyl_carrier_protein_n_C181" compartment="apicoplast" fbc:charge="0" fbc:chemicalFormula="C29H53N2O8PRS"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_odecoa_ap" name="Octadecenoyl_CoA_n_C181CoA" compartment="apicoplast" fbc:charge="0" fbc:chemicalFormula="C39H64N7O17P3S"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_odecoa_c" name="Octadecenoyl_CoA_n_C181CoA" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C39H64N7O17P3S"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_odecoa_e" name="Octadecenoyl_CoA_n_C181CoA" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="C39H64N7O17P3S"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_oh1_c" name="hydroxide_ion" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="HO"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_oh1_m" name="hydroxide_ion" compartment="mitochondria" fbc:charge="0" fbc:chemicalFormula="HO"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_orn_c" name="Ornithine" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C5H13N2O2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_orn_e" name="Ornithine" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="C5H13N2O2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_orot5p_c" name="Orotidine_5_phosphate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C10H10N2O11P"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_orot_c" name="Orotate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C5H3N2O4"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_orot_m" name="Orotate" compartment="mitochondria" fbc:charge="0" fbc:chemicalFormula="C5H3N2O4"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_oxa_c" name="xalate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C2O4"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_oxa_e" name="xalate" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="C2O4"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pa120_ap" name="1_2_didodecanoyl_sn_glycerol_3_phosphate" compartment="apicoplast" fbc:charge="0" fbc:chemicalFormula="C27H51O8P1"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pa120_c" name="1_2_didodecanoyl_sn_glycerol_3_phosphate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C27H51O8P1"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pa140_ap" name="1_2_ditetradecanoyl_sn_glycerol_3_phosphate" compartment="apicoplast" fbc:charge="0" fbc:chemicalFormula="C31H59O8P1"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pa140_c" name="1_2_ditetradecanoyl_sn_glycerol_3_phosphate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C31H59O8P1"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pa141_ap" name="1_2_ditetradec_7_enoyl_sn_glycerol_3_phosphate" compartment="apicoplast" fbc:charge="0" fbc:chemicalFormula="C31H55O8P1"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pa141_c" name="1_2_ditetradec_7_enoyl_sn_glycerol_3_phosphate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C31H55O8P1"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pa160_ap" name="1_2_dihexadecanoyl_sn_glycerol_3_phosphate" compartment="apicoplast" fbc:charge="0" fbc:chemicalFormula="C35H67O8P1"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pa160_c" name="1_2_dihexadecanoyl_sn_glycerol_3_phosphate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C35H67O8P1"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pa161_ap" name="1_2_dihexadec_9_enoyl_sn_glycerol_3_phosphate" compartment="apicoplast" fbc:charge="0" fbc:chemicalFormula="C35H63O8P1"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pa161_c" name="1_2_dihexadec_9_enoyl_sn_glycerol_3_phosphate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C35H63O8P1"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pa180_ap" name="1_2_dioctadecanoyl_sn_glycerol_3_phosphate" compartment="apicoplast" fbc:charge="0" fbc:chemicalFormula="C39H75O8P1"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pa180_c" name="1_2_dioctadecanoyl_sn_glycerol_3_phosphate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C39H75O8P1"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pa181_ap" name="1_2_dioctadec_11_enoyl_sn_glycerol_3_phosphate" compartment="apicoplast" fbc:charge="0" fbc:chemicalFormula="C39H71O8P1"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pa181_c" name="1_2_dioctadec_11_enoyl_sn_glycerol_3_phosphate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C39H71O8P1"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pail_c" name="phosphatidylinositol" compartment="cytosol" fbc:charge="[-1]" fbc:chemicalFormula="['C9H16O9PRCO2R2CO2']"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_palmACP_ap" name="Palmitoyl_ACP_n_C160ACP" compartment="apicoplast" fbc:charge="0" fbc:chemicalFormula="C27H51N2O8PRS"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pan4p_c" name="Pantetheine_4_phosphate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C11H21N2O7PS"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pap_c" name="Adenosine_3_5_bisphosphate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C10H11N5O10P2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pap_e" name="Adenosine_3_5_bisphosphate" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="C10H11N5O10P2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pc_c" name="Phosphatidylcholine" compartment="cytosol" fbc:charge="[]" fbc:chemicalFormula="[]"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pc_e" name="Phosphatidylcholine" compartment="extracellular" fbc:charge="[]" fbc:chemicalFormula="[]"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pdx5p_c" name="Pyridoxine_5_phosphate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C8H10NO6P"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pe120_c" name="phosphatidylethanolamine_didodecanoyl_n_C120" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C29H58N1O8P1"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pe120_e" name="phosphatidylethanolamine_didodecanoyl_n_C120" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="C29H58N1O8P1"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pe140_c" name="phosphatidylethanolamine_ditetradecanoyl_n_C140" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C33H66N1O8P1"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pe140_e" name="phosphatidylethanolamine_ditetradecanoyl_n_C140" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="C33H66N1O8P1"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pe141_c" name="phosphatidylethanolamine_ditetradec_7_enoyl_n_C141" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C33H62N1O8P1"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pe141_e" name="phosphatidylethanolamine_ditetradec_7_enoyl_n_C141" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="C33H62N1O8P1"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pe160_c" name="phosphatidylethanolamine_dihexadecanoyl_n_C160" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C37H74N1O8P1"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pe160_e" name="phosphatidylethanolamine_dihexadecanoyl_n_C160" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="C37H74N1O8P1"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pe161_c" name="phosphatidylethanolamine_dihexadec_9enoyl_n_C161" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C37H70N1O8P1"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pe161_e" name="phosphatidylethanolamine_dihexadec_9enoyl_n_C161" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="C37H70N1O8P1"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pe180_c" name="phosphatidylethanolamine_dioctadecanoyl_n_C180" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C41H82N1O8P1"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pe180_e" name="phosphatidylethanolamine_dioctadecanoyl_n_C180" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="C41H82N1O8P1"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pe181_c" name="phosphatidylethanolamine_dioctadec_11_enoyl_n_C181" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C41H78N1O8P1"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pe181_e" name="phosphatidylethanolamine_dioctadec_11_enoyl_n_C181" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="C41H78N1O8P1"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pe_c" name="Phosphatidylethanolamine" compartment="cytosol" fbc:charge="[]" fbc:chemicalFormula="[]"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pe_e" name="Phosphatidylethanolamine" compartment="extracellular" fbc:charge="[]" fbc:chemicalFormula="[]"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pendp_c" name="all_trans_Pentaprenyl_diphosphate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C25H41O7P2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pendp_m" name="all_trans_Pentaprenyl_diphosphate" compartment="mitochondria" fbc:charge="0" fbc:chemicalFormula="C25H41O7P2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pep_ap" name="Phosphoenolpyruvate" compartment="apicoplast" fbc:charge="0" fbc:chemicalFormula="C3H2O6P"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pep_c" name="Phosphoenolpyruvate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C3H2O6P"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pg120_c" name="Phosphatidylglycerol_didodecanoyl_n_C120" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C30H58O10P1"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pg140_c" name="Phosphatidylglycerol_ditetradecanoyl_n_C140" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C34H66O10P1"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pg141_c" name="Phosphatidylglycerol_ditetradec_7_enoyl_n_C141" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C34H62O10P1"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pg160_c" name="Phosphatidylglycerol_dihexadecanoyl_n_C160" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C38H74O10P1"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pg161_c" name="Phosphatidylglycerol_dihexadec_9_enoyl_n_C161" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C38H70O10P1"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pg180_c" name="Phosphatidylglycerol_dioctadecanoyl_n_C180" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C42H82O10P1"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pg181_c" name="Phosphatidylglycerol_dioctadec_11_enoyl_n_C181" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C42H78O10P1"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pgp120_c" name="Phosphatidylglycerophosphate_didodecanoyl_n_C120" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C30H57O13P2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pgp140_c" name="Phosphatidylglycerophosphate_ditetradecanoyl_n_C140" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C34H65O13P2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pgp141_c" name="Phosphatidylglycerophosphate_ditetradec_7_enoyl_n_C141" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C34H61O13P2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pgp160_c" name="Phosphatidylglycerophosphate_dihexadecanoyl_n_C160" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C38H73O13P2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pgp161_c" name="Phosphatidylglycerophosphate_dihexadec_9_enoyl_n_C161" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C38H69O13P2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pgp180_c" name="Phosphatidylglycerophosphate_dioctadecanoyl_n_C180" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C42H81O13P2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pgp181_c" name="Phosphatidylglycerophosphate_dioctadec_11_enoyl_n_C181" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C42H77O13P2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_phe__L_c" name="L_Phenylalanine" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C9H11NO2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_phe__L_e" name="L_Phenylalanine" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="C9H11NO2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pheme_ap" name="Protoheme" compartment="apicoplast" fbc:charge="0" fbc:chemicalFormula="C34H30FeN4O4"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pheme_c" name="Protoheme" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C34H30FeN4O4"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pheme_m" name="Protoheme" compartment="mitochondria" fbc:charge="0" fbc:chemicalFormula="C34H30FeN4O4"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_phpyr_c" name="Phenylpyruvate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C9H7O3"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pi_ap" name="Phosphate" compartment="apicoplast" fbc:charge="0" fbc:chemicalFormula="HO4P"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pi_c" name="Phosphate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="HO4P"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pi_e" name="Phosphate" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="HO4P"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pi_m" name="Phosphate" compartment="mitochondria" fbc:charge="0" fbc:chemicalFormula="HO4P"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pmtcoa_ap" name="Palmitoyl_CoA_n_C160CoA" compartment="apicoplast" fbc:charge="0" fbc:chemicalFormula="C37H62N7O17P3S"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pmtcoa_c" name="Palmitoyl_CoA_n_C160CoA" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C37H62N7O17P3S"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pmtcoa_e" name="Palmitoyl_CoA_n_C160CoA" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="C37H62N7O17P3S"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pnto__R_c" name="R_Pantothenate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C9H16NO5"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pnto__R_e" name="R_Pantothenate" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="C9H16NO5"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ppa_c" name="Propionate_n_C30" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C3H5O2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ppa_e" name="Propionate_n_C30" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="C3H5O2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ppbng_ap" name="Porphobilinogen" compartment="apicoplast" fbc:charge="0" fbc:chemicalFormula="C10H13N2O4"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ppcoa_c" name="Propanoyl_CoA" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C24H36N7O17P3S"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ppi_ap" name="Diphosphate" compartment="apicoplast" fbc:charge="0" fbc:chemicalFormula="HO7P2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ppi_c" name="Diphosphate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="HO7P2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ppi_m" name="Diphosphate" compartment="mitochondria" fbc:charge="0" fbc:chemicalFormula="HO7P2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ppp9_ap" name="Protoporphyrin" compartment="apicoplast" fbc:charge="0" fbc:chemicalFormula="C34H32N4O4"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ppp9_c" name="Protoporphyrin" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C34H32N4O4"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ppp9_m" name="Protoporphyrin" compartment="mitochondria" fbc:charge="0" fbc:chemicalFormula="C34H32N4O4"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pppg9_ap" name="Protoporphyrinogen_IX" compartment="apicoplast" fbc:charge="0" fbc:chemicalFormula="C34H38N4O4"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pppg9_c" name="Protoporphyrinogen_IX" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C34H38N4O4"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pppg9_m" name="Protoporphyrinogen_IX" compartment="mitochondria" fbc:charge="0" fbc:chemicalFormula="C34H38N4O4"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pppi_c" name="Inorganic_triphosphate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="HO10P3"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pro__L_c" name="L_Proline" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C5H9NO2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pro__L_e" name="L_Proline" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="C5H9NO2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_progly_c" name="L_Prolinylglycine" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C7H12N2O3"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_prpp_c" name="5_Phospho_alpha_D_ribose_1_diphosphate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C5H8O14P3"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ps120_c" name="phosphatidylserine_didodecanoyl_n_C120" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C30H57N1O10P1"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ps140_c" name="phosphatidylserine_ditetradecanoyl_n_C140" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C34H65N1O10P1"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ps141_c" name="phosphatidylserine_ditetradec_7_enoyl_n_C141" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C34H61N1O10P1"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ps160_c" name="phosphatidylserine_dihexadecanoyl_n_C160" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C38H73N1O10P1"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ps161_c" name="phosphatidylserine_dihexadec_9_enoyl_n_C161" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C38H69N1O10P1"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ps180_c" name="phosphatidylserine_dioctadecanoyl_n_C180" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C42H81N1O10P1"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ps181_c" name="phosphatidylserine_dioctadec_11_enoyl_n_C181" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C42H77N1O10P1"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_psd5p_c" name="Pseudouridine_5_phosphate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C9H11N2O9P"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ptd145bp_c" name="1 Phosphatidyl D myo inositol 4 5 bisphosphate " compartment="cytosol" fbc:charge="[]" fbc:chemicalFormula="[]"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ptd1ino_c" name="Phosphatidyl 1D myo inositol" compartment="cytosol" fbc:charge="[]" fbc:chemicalFormula="[]"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ptd1ino_e" name="Phosphatidyl 1D myo inositol" compartment="extracellular" fbc:charge="[]" fbc:chemicalFormula="[]"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ptd3ino_c" name="Phosphatidyl 3D myo inositol" compartment="cytosol" fbc:charge="[]" fbc:chemicalFormula="[]"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ptd4ino_c" name="Phosphatidyl 4D myo inositol" compartment="cytosol" fbc:charge="[]" fbc:chemicalFormula="[]"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ptrc_c" name="Putrescine" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C4H14N2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ptrc_e" name="Putrescine" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="C4H14N2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pyam5p_c" name="Pyridoxamine_5_phosphate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C8H12N2O5P"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pydam_c" name="Pyridoxamine" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C8H13N2O2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pydam_e" name="Pyridoxamine" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="C8H13N2O2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pydx5p_c" name="Pyridoxal_5_phosphate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C8H8NO6P"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pydx_c" name="Pyridoxal" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C8H9NO3"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pydx_e" name="Pyridoxal" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="C8H9NO3"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pydxn_c" name="Pyridoxine" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C8H11NO3"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pydxn_e" name="Pyridoxine" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="C8H11NO3"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pyr_ap" name="Pyruvate" compartment="apicoplast" fbc:charge="0" fbc:chemicalFormula="C3H3O3"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pyr_c" name="Pyruvate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C3H3O3"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pyr_e" name="Pyruvate" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="C3H3O3"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_q8_c" name="Ubiquinone_8" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C49H74O4"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_q8_m" name="Ubiquinone_8" compartment="mitochondria" fbc:charge="0" fbc:chemicalFormula="C49H74O4"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_q8h2_c" name="Ubiquinol_8" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C49H76O4"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_q8h2_m" name="Ubiquinol_8" compartment="mitochondria" fbc:charge="0" fbc:chemicalFormula="C49H76O4"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_r15bp_c" name="D_Ribose_1_5_bisphosphate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C5H8O11P2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_r1p_c" name="alpha_D_Ribose_1_phosphate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C5H9O8P"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_r5p_c" name="alpha_D_Ribose_5_phosphate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C5H9O8P"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ribflv_c" name="Riboflavin" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C17H20N4O6"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ribflv_e" name="Riboflavin" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="C17H20N4O6"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ru5p__D_c" name="D_Ribulose_5_phosphate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C5H9O8P"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_saccrp__L_c" name="L_Saccharopine" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C11H19N2O6"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_sbt__D_c" name="D_Sorbitol" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C6H14O6"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_sbt__D_e" name="D_Sorbitol" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="C6H14O6"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_seln_c" name="Selenide" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="HSe"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_selnp_c" name="Selenophosphate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="H2O3PSe"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ser__L_c" name="L_Serine" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C3H7NO3"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ser__L_e" name="L_Serine" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="C3H7NO3"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_sertrna_c" name="L_Seryl_tRNA_Ser" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C3H6NO2R"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_sertrna_sec_c" name="L_Seryl_tRNA_Sec" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C3H6NO2R"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_skm5p_c" name="Shikimate_5_phosphate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C7H8O8P"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_skm_c" name="Shikimate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C7H9O5"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_so4_c" name="Sulfate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="O4S"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_so4_e" name="Sulfate" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="O4S"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_sphgn_c" name="Sphinganine" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C18H40NO2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_sphmyln_c" name="Sphingomyelin (generic)" compartment="cytosol" fbc:charge="[0]" fbc:chemicalFormula="['C23H48N2O5PRCO']"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_spmd_c" name="Spermidine" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C7H22N3"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_spmd_e" name="Spermidine" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="C7H22N3"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_stcoa_ap" name="Stearoyl_CoA_n_C180CoA" compartment="apicoplast" fbc:charge="0" fbc:chemicalFormula="C39H66N7O17P3S"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_stcoa_c" name="Stearoyl_CoA_n_C180CoA" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C39H66N7O17P3S"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_stcoa_e" name="Stearoyl_CoA_n_C180CoA" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="C39H66N7O17P3S"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_succ_c" name="Succinate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C4H4O4"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_succ_e" name="Succinate" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="C4H4O4"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_succ_m" name="Succinate" compartment="mitochondria" fbc:charge="0" fbc:chemicalFormula="C4H4O4"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_succoa_m" name="Succinyl_CoA" compartment="mitochondria" fbc:charge="0" fbc:chemicalFormula="C25H35N7O19P3S"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_t3c11vaceACP_ap" name="trans_3_cis_11_vacceoyl_acyl_carrier_protein" compartment="apicoplast" fbc:charge="0" fbc:chemicalFormula="C29H51N2O8PRS"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_t3c5ddeceACP_ap" name="trans_3_cis_5_dodecenoyl_acyl_carrier_protein" compartment="apicoplast" fbc:charge="0" fbc:chemicalFormula="C23H39N2O8PRS"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_t3c7mrseACP_ap" name="trans_3_cis_7_myristoleoyl_acyl_carrier_protein" compartment="apicoplast" fbc:charge="0" fbc:chemicalFormula="C25H43N2O8PRS"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_t3c9palmeACP_ap" name="trans_3_cis_9_palmitoleoyl_acyl_carrier_protein" compartment="apicoplast" fbc:charge="0" fbc:chemicalFormula="C27H47N2O8PRS"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_tag_c" name="triacylglycerols (total)" compartment="cytosol" fbc:charge="[]" fbc:chemicalFormula="[]"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_tdcoa_ap" name="Tetradecanoyl_CoA_n_C140CoA" compartment="apicoplast" fbc:charge="0" fbc:chemicalFormula="C35H58N7O17P3S"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_tdcoa_c" name="Tetradecanoyl_CoA_n_C140CoA" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C35H58N7O17P3S"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_tdcoa_e" name="Tetradecanoyl_CoA_n_C140CoA" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="C35H58N7O17P3S"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_tddec2eACP_ap" name="trans_Dodec_2_enoyl_acyl_carrier_protein" compartment="apicoplast" fbc:charge="0" fbc:chemicalFormula="C23H41N2O8PRS"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_tdeACP_ap" name="cis_tetradec_7_enoyl_acyl_carrier_protein_n_C141" compartment="apicoplast" fbc:charge="0" fbc:chemicalFormula="C25H45N2O8PRS"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_tdec2eACP_ap" name="trans_Dec_2_enoyl_acyl_carrier_protein" compartment="apicoplast" fbc:charge="0" fbc:chemicalFormula="C21H37N2O8PRS"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_tdecoa_ap" name="Tetradecenoyl_CoA_n_C141CoA" compartment="apicoplast" fbc:charge="0" fbc:chemicalFormula="C35H56N7O17P3S"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_tdecoa_c" name="Tetradecenoyl_CoA_n_C141CoA" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C35H56N7O17P3S"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_tdecoa_e" name="Tetradecenoyl_CoA_n_C141CoA" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="C35H56N7O17P3S"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_thex2eACP_ap" name="trans_Hex_2_enoyl_acyl_carrier_protein" compartment="apicoplast" fbc:charge="0" fbc:chemicalFormula="C17H29N2O8PRS"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_thf_c" name="5_6_7_8_Tetrahydrofolate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C19H21N7O6"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_thf_m" name="5_6_7_8_Tetrahydrofolate" compartment="mitochondria" fbc:charge="0" fbc:chemicalFormula="C19H21N7O6"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_thfglu_c" name="Tetrahydrofolyl_Glu_2" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C24H27N8O9"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_thm_c" name="Thiamin" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C12H17N4OS"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_thm_e" name="Thiamin" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="C12H17N4OS"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_thmmp_c" name="Thiamin_monophosphate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C12H16N4O4PS"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_thmpp_c" name="Thiamine_diphosphate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C12H16N4O7P2S"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_thr__L_c" name="L_Threonine" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C4H9NO3"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_thr__L_e" name="L_Threonine" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="C4H9NO3"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_thrtrna_c" name="L_Threonyl_tRNA_Thr" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C4H8NO2R"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_tmrs2eACP_ap" name="trans_Tetradec_2_enoyl_acyl_carrier_protein" compartment="apicoplast" fbc:charge="0" fbc:chemicalFormula="C25H45N2O8PRS"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_toct2eACP_ap" name="trans_Oct_2_enoyl_acyl_carrier_protein" compartment="apicoplast" fbc:charge="0" fbc:chemicalFormula="C19H33N2O8PRS"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_toctd2eACP_ap" name="trans_octadec_2_enoyl_acyl_carrier_protein" compartment="apicoplast" fbc:charge="0" fbc:chemicalFormula="C29H53N2O8PRS"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_tpalm2eACP_ap" name="trans_Hexadec_2_enoyl_acyl_carrier_protein" compartment="apicoplast" fbc:charge="0" fbc:chemicalFormula="C27H49N2O8PRS"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_trdox_c" name="Oxidized_thioredoxin" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="X"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_trdrd_c" name="Reduced_thioredoxin" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="XH2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_trdrd_m" name="Reduced_thioredoxin" compartment="mitochondria" fbc:charge="0" fbc:chemicalFormula="XH2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_trnaala_c" name="tRNA_Ala" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="R"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_trnaarg_c" name="tRNA_Arg" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="R"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_trnaasn_c" name="tRNA_Asn" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C10H17O10PR2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_trnaasp_c" name="tRNA_Asp" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="R"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_trnacys_c" name="tRNA_Cys" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="R"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_trnagln_c" name="tRNA_Gln" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="R"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_trnaglu_c" name="tRNA_Glu" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="R"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_trnagly_c" name="tRNA_Gly" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="R"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_trnahis_c" name="tRNA_His" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="R"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_trnaile_c" name="tRNA_Ile" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="R"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_trnaleu_c" name="tRNA_Leu" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="R"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_trnalys_c" name="tRNA_Lys" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="R"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_trnamet_c" name="tRNA_Met" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="R"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_trnaphe_c" name="tRNA_Phe" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="R"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_trnapro_c" name="tRNA_Pro" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="R"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_trnasecys_c" name="tRNA_SeCys" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="R"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_trnaser_c" name="tRNA_Ser" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="R"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_trnathr_c" name="tRNA_Thr" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="R"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_trnatrp_c" name="tRNA_Trp" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="R"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_trnatyr_c" name="tRNA_Tyr" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="R"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_trnaval_c" name="tRNA_Val" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="R"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_trp__L_c" name="L_Tryptophan" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C11H12N2O2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_trp__L_e" name="L_Tryptophan" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="C11H12N2O2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ttc_ap" name="tetracosanoate_n_C240" compartment="apicoplast" fbc:charge="0" fbc:chemicalFormula="C24H47O2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ttdca_ap" name="tetradecanoate_n_C140" compartment="apicoplast" fbc:charge="0" fbc:chemicalFormula="C14H27O2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ttdca_c" name="tetradecanoate_n_C140" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C14H27O2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ttdca_e" name="tetradecanoate_n_C140" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="C14H27O2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ttdcea_ap" name="tetradecenoate_n_C141" compartment="apicoplast" fbc:charge="0" fbc:chemicalFormula="C14H25O2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ttdcea_c" name="tetradecenoate_n_C141" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C14H25O2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ttdcea_e" name="tetradecenoate_n_C141" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="C14H25O2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_tyr__L_c" name="L_Tyrosine" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C9H11NO3"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_tyr__L_e" name="L_Tyrosine" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="C9H11NO3"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_tyr__L_m" name="L_Tyrosine" compartment="mitochondria" fbc:charge="0" fbc:chemicalFormula="C9H11NO3"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_tyrtrna_c" name="L_Tyrosyl_tRNA_Tyr" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C9H10NO2R"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_uacgam_c" name="UDP_N_acetyl_D_glucosamine" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C17H25N3O17P2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_udp_c" name="UDP" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C9H11N2O12P2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_udpg_c" name="UDPglucose" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C15H22N2O17P2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ump_c" name="UMP" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C9H11N2O9P"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_up4u_c" name="P1,P4-Bis(5-uridyl) tetraphosphate" compartment="cytosol" fbc:charge="[]" fbc:chemicalFormula="['C18H26N4O23P4']"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_uppg3_ap" name="Uroporphyrinogen_III" compartment="apicoplast" fbc:charge="0" fbc:chemicalFormula="C40H36N4O16"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ura_c" name="Uracil" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C4H4N2O2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_urea_c" name="Urea" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="CH4N2O"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_urea_e" name="Urea" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="CH4N2O"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_uri_c" name="Uridine" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C9H12N2O6"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_utp_c" name="UTP" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C9H11N2O15P3"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_val__L_c" name="L_Valine" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C5H11NO2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_val__L_e" name="L_Valine" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="C5H11NO2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_valtrna_c" name="L_Valyl_tRNA_Val" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C5H10NOR"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_xan_c" name="Xanthine" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C5H4N4O2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_xan_e" name="Xanthine" compartment="extracellular" fbc:charge="0" fbc:chemicalFormula="C5H4N4O2"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_xmp_c" name="Xanthosine_5_phosphate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C10H11N4O9P"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_xolest2_c" name="Cholesterol ester" compartment="cytosol" fbc:charge="[0]" fbc:chemicalFormula="['C24H46NO7RCO']"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_xolest2_e" name="Cholesterol ester" compartment="extracellular" fbc:charge="[0]" fbc:chemicalFormula="['C24H46NO7RCO']"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_xtsn_c" name="Xanthosine" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C10H12N4O6"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_xu5p__D_c" name="D_Xylulose_5_phosphate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C5H9O8P"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pail_e" name="phosphatidylinositol" compartment="extracellular" fbc:charge="[-1]" fbc:chemicalFormula="['C9H16O9PRCO2R2CO2']"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_g3pc_e" name="g3pc[e]" compartment="extracellular" fbc:charge="0"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_g3pi_e" name="g3pi[e]" compartment="extracellular" fbc:charge="0"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_g3ps_e" name="g3ps[e]" compartment="extracellular" fbc:charge="0"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_dolichol_e" name="dolichol[e]" compartment="extracellular" fbc:charge="0"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_seln_e" name="seln[e]" compartment="extracellular" fbc:charge="0"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_2agpe120_e" name="2agpe120[e]" compartment="extracellular" fbc:charge="0"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_2agpe140_e" name="2agpe140[e]" compartment="extracellular" fbc:charge="0"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_2agpe141_e" name="2agpe141[e]" compartment="extracellular" fbc:charge="0"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_2agpe160_e" name="2agpe160[e]" compartment="extracellular" fbc:charge="0"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_2agpe161_e" name="2agpe161[e]" compartment="extracellular" fbc:charge="0"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_2agpe180_e" name="2agpe180[e]" compartment="extracellular" fbc:charge="0"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_2agpe181_e" name="2agpe181[e]" compartment="extracellular" fbc:charge="0"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_2agpg120_e" name="2agpg120[e]" compartment="extracellular" fbc:charge="0"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_2agpg140_e" name="2agpg140[e]" compartment="extracellular" fbc:charge="0"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_2agpg141_e" name="2agpg141[e]" compartment="extracellular" fbc:charge="0"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_2agpg160_e" name="2agpg160[e]" compartment="extracellular" fbc:charge="0"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_2agpg161_e" name="2agpg161[e]" compartment="extracellular" fbc:charge="0"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_2agpg180_e" name="2agpg180[e]" compartment="extracellular" fbc:charge="0"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_2agpg181_e" name="2agpg181[e]" compartment="extracellular" fbc:charge="0"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_2ddecg3p_e" name="2ddecg3p[e]" compartment="extracellular" fbc:charge="0"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_gdp_ap" name="gdp[ap]" compartment="apicoplast" fbc:charge="0"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_gtp_ap" name="gtp[ap]" compartment="apicoplast" fbc:charge="0"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_mi13456p_e" name="mi13456p[e]" compartment="extracellular" fbc:charge="0"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_mi1345p_e" name="mi1345p[e]" compartment="extracellular" fbc:charge="0"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_mi134p_e" name="mi134p[e]" compartment="extracellular" fbc:charge="0"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_mi1456p_e" name="mi1456p[e]" compartment="extracellular" fbc:charge="0"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_mi145p_e" name="mi145p[e]" compartment="extracellular" fbc:charge="0"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_mi14p_e" name="mi14p[e]" compartment="extracellular" fbc:charge="0"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_mi1p__D_e" name="mi1p_D[e]" compartment="extracellular" fbc:charge="0"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_mi34p_e" name="mi34p[e]" compartment="extracellular" fbc:charge="0"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_mi4p__D_e" name="mi4p_D[e]" compartment="extracellular" fbc:charge="0"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_dimp_e" name="dimp[e]" compartment="extracellular" fbc:charge="0"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_apoACP_ap" name="apoACP[ap]" compartment="apicoplast" fbc:charge="0"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pap_ap" name="pap[ap]" compartment="apicoplast" fbc:charge="0"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_acACP_ap" name="acACP[ap]" compartment="apicoplast" fbc:charge="0"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_Asn_X_Ser_Thr_e" name="Asn_X_Ser/Thr[e]" compartment="extracellular" fbc:charge="0"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_citr__L_c" name="citrul[c]" compartment="cytosol" fbc:charge="0"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_lald__D_c" name="lald_D[c]" compartment="cytosol" fbc:charge="0"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_udcpdp_c" name="udcpdp[c]" compartment="cytosol" fbc:charge="0"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_15dap_c" name="15dap[c]" compartment="cytosol" fbc:charge="0"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_argtrna_c" name="argtrna[c]" compartment="cytosol" fbc:charge="0"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_fadh2_c" name="fadh2[c]" compartment="cytosol" fbc:charge="0"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_nh3_c" name="nh3[c]" compartment="cytosol" fbc:charge="0"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_glu__L_ap" name="glu_L[ap]" compartment="apicoplast" fbc:charge="0"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_akg_ap" name="akg[ap]" compartment="apicoplast" fbc:charge="0"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_nh3_ap" name="nh3[ap]" compartment="apicoplast" fbc:charge="0"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_naglc2p__L_c" name="naglc2p_L[c]" compartment="cytosol" fbc:charge="0"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_m4mpdol__L_c" name="m4mpdol_L[c]" compartment="cytosol" fbc:charge="0"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_m8mpdol__L_c" name="m8mpdol_L[c]" compartment="cytosol" fbc:charge="0"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pheme_fv" name="pheme[fv]" compartment="food vacuole" fbc:charge="0"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_psertrna_sec_c" name="O-Phosphoseryl-tRNA(Sec)" compartment="cytosol" fbc:charge="[]" fbc:chemicalFormula="[]"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_sectrna_c" name="sectrna[c]" compartment="cytosol" fbc:charge="0"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_trptrna_c" name="trptrna[c]" compartment="cytosol" fbc:charge="0"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_34hpp_c" name="34hpp[c]" compartment="cytosol" fbc:charge="0"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_glntrna_c" name="glntrna[c]" compartment="cytosol" fbc:charge="0"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_s7p_c" name="s7p[c]" compartment="cytosol" fbc:charge="0"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_dcmp_c" name="dcmp[c]" compartment="cytosol" fbc:charge="0"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_mmet_c" name="mmet[c]" compartment="cytosol" fbc:charge="0"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_hemozoin_fv" name="hemozoin" compartment="food vacuole" fbc:charge="[]" fbc:chemicalFormula="[]"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_hemozoin_e" name="hemozoin" compartment="extracellular" fbc:charge="[]" fbc:chemicalFormula="[]"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_4pyrdx_c" name="pyrdat[c]" compartment="cytosol" fbc:charge="0"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_gluside_e" name="D-glucosyl-N-acylsphingosine" compartment="extracellular" fbc:charge="[0]" fbc:chemicalFormula="[]"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_lac__L_e" name="lac_L[e]" compartment="extracellular" fbc:charge="0"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_sprm_c" name="sperm[c]" compartment="cytosol" fbc:charge="0"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_fol_c" name="fol[c]" compartment="cytosol" fbc:charge="0"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_asntrna_c" name="asntrna[c]" compartment="cytosol" fbc:charge="0"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_phetrna_c" name="phetrna[c]" compartment="cytosol" fbc:charge="0"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_mgacpail_c" name="Mannosyl-glucosaminyl-acylphosphatidylinositiol" compartment="cytosol" fbc:charge="[0]" fbc:chemicalFormula="[]"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_tag6p__D_c" name="tag6p_D[c]" compartment="cytosol" fbc:charge="0"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_tagdp__D_c" name="tagdp_D[c]" compartment="cytosol" fbc:charge="0"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_protrna_c" name="protrna[c]" compartment="cytosol" fbc:charge="0"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_asptrna_c" name="asptrna[c]" compartment="cytosol" fbc:charge="0"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_glytrna_c" name="glytrna[c]" compartment="cytosol" fbc:charge="0"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_lystrna_c" name="lystrna[c]" compartment="cytosol" fbc:charge="0"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_gp4g_c" name="gp4g[c]" compartment="cytosol" fbc:charge="0"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ap4a_c" name="ap4a[c]" compartment="cytosol" fbc:charge="0"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_progly_e" name="progly[e]" compartment="extracellular" fbc:charge="0"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_idp_c" name="idp[c]" compartment="cytosol" fbc:charge="0"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_sphmyln_e" name="Sphingomyelin (generic)" compartment="extracellular" fbc:charge="[0]" fbc:chemicalFormula="['C23H48N2O5PRCO']"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_sphmyln_hs_c" name="sphmyln_host[c]" compartment="cytosol" fbc:charge="0"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_hmfurn_c" name="hmfurn[c]" compartment="cytosol" fbc:charge="0"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_o2s_c" name="o2s[c]" compartment="cytosol" fbc:charge="0"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_o2s_m" name="o2s[m]" compartment="mitochondria" fbc:charge="0"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_gthox_ap" name="gthox[ap]" compartment="apicoplast" fbc:charge="0"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_gthrd_ap" name="gthrd[ap]" compartment="apicoplast" fbc:charge="0"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_h2o2_ap" name="h2o2[ap]" compartment="apicoplast" fbc:charge="0"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ROOH_ap" name="hydroperoxy group on protein" compartment="apicoplast" fbc:charge="[]" fbc:chemicalFormula="[]"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ROH_ap" name="hydroxyl group on protein" compartment="apicoplast" fbc:charge="[]" fbc:chemicalFormula="[]"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_protein_t_c" name="glutathione-protein conjugate (intracellular) " compartment="cytosol" fbc:charge="[]" fbc:chemicalFormula="[]"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_gthox_protein_c" name="oxidized glutathione and protein" compartment="cytosol" fbc:charge="[]" fbc:chemicalFormula="[]"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_gthox_protein_e" name="oxidized glutathione and protein" compartment="extracellular" fbc:charge="[]" fbc:chemicalFormula="[]"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_protein_t_e" name="glutathione-protein conjugate (extracellular) " compartment="extracellular" fbc:charge="[]" fbc:chemicalFormula="[]"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ROOH_c" name="hydroperoxy group on protein" compartment="cytosol" fbc:charge="[]" fbc:chemicalFormula="[]"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ROH_c" name="hydroxyl group on protein" compartment="cytosol" fbc:charge="[]" fbc:chemicalFormula="[]"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ROOH_m" name="hydroperoxy group on protein" compartment="mitochondria" fbc:charge="[]" fbc:chemicalFormula="[]"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ROH_m" name="hydroxyl group on protein" compartment="mitochondria" fbc:charge="[]" fbc:chemicalFormula="[]"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_trdox_m" name="trdox[m]" compartment="mitochondria" fbc:charge="0"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_protdt_c" name="proteinSS[c]" compartment="cytosol" fbc:charge="0"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_protds_c" name="proteinSHSH[c]" compartment="cytosol" fbc:charge="0"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_protdt_ap" name="proteinSS[ap]" compartment="apicoplast" fbc:charge="0"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_protds_ap" name="proteinSHSH[ap]" compartment="apicoplast" fbc:charge="0"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_protdt_m" name="proteinSS[m]" compartment="mitochondria" fbc:charge="0"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_protds_m" name="proteinSHSH[m]" compartment="mitochondria" fbc:charge="0"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_gthrd_m" name="gthrd[m]" compartment="mitochondria" fbc:charge="0"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ser__L_m" name="ser_L[m]" compartment="mitochondria" fbc:charge="0"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ser__L_ap" name="ser_L[ap]" compartment="apicoplast" fbc:charge="0"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_thf_ap" name="thf[ap]" compartment="apicoplast" fbc:charge="0"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_gly_ap" name="gly[ap]" compartment="apicoplast" fbc:charge="0"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_mlthf_ap" name="mlthf[ap]" compartment="apicoplast" fbc:charge="0"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_mlthf_e" name="mlthf[e]" compartment="extracellular" fbc:charge="0"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_all_pc_c" name="Phosphatidylcholine (total)" compartment="cytosol" fbc:charge="[]" fbc:chemicalFormula="[]"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_all_pe_c" name="Phosphatidylethanolamine (total)" compartment="cytosol" fbc:charge="[]" fbc:chemicalFormula="[]"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_all_ps_c" name="Phosphatidylserine (total)" compartment="cytosol" fbc:charge="[]" fbc:chemicalFormula="[]"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_all_pi_c" name="Phosphatidylinositol  (total)" compartment="cytosol" fbc:charge="[]" fbc:chemicalFormula="[]"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_all_pg_c" name="Phosphatidylglycerol (total)" compartment="cytosol" fbc:charge="[]" fbc:chemicalFormula="[]"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_all_apg_c" name="acyl - phosphatidylglycerol (total)" compartment="cytosol" fbc:charge="[]" fbc:chemicalFormula="[]"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_all_dgl_c" name="diacyl - phosphatidylglycerol (total)" compartment="cytosol" fbc:charge="[]" fbc:chemicalFormula="[]"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_acoa_c" name="acoa[c]" compartment="cytosol" fbc:charge="0"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_malcoa_c" name="malcoa[c]" compartment="cytosol" fbc:charge="0"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_bm_protein_c" name="protein[c]" compartment="cytosol" fbc:charge="0"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_protein_e" name="protein[e]" compartment="extracellular" fbc:charge="0"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_bm_lipid_c" name="lipid[c]" compartment="cytosol" fbc:charge="0"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_biomass_c" name="biomass[c]" compartment="cytosol" fbc:charge="0"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_heme_degraded_c" name="degraded heme" compartment="cytosol" fbc:charge="[]" fbc:chemicalFormula="[]"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_heme_degraded_fv" name="degraded heme" compartment="food vacuole" fbc:charge="[]" fbc:chemicalFormula="[]"/>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_adprib_e" name="ADPribose C15H21N5O14P2" metaid="M_adprib_e" sboTerm="SBO:0000247" compartment="extracellular" fbc:charge="-2" fbc:chemicalFormula="C15H21N5O14P2">
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_10fthf_c" name="10_Formyltetrahydrofolate" compartment="c" fbc:charge="0" fbc:chemicalFormula="C20H21N7O7"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_12dgr120_c" name="1_2_Diacyl_sn_glycerol_didodecanoyl_n_C120" compartment="c" fbc:charge="0" fbc:chemicalFormula="C27H52O5"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_12dgr120_e" name="1_2_Diacyl_sn_glycerol_didodecanoyl_n_C120" compartment="e" fbc:charge="0" fbc:chemicalFormula="C27H52O5"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_12dgr140_c" name="1_2_Diacyl_sn_glycerol_ditetradecanoyl_n_C140" compartment="c" fbc:charge="0" fbc:chemicalFormula="C31H60O5"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_12dgr140_e" name="1_2_Diacyl_sn_glycerol_ditetradecanoyl_n_C140" compartment="e" fbc:charge="0" fbc:chemicalFormula="C31H60O5"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_12dgr141_c" name="1_2_Diacyl_sn_glycerol_ditetradec_7_enoyl_n_C141" compartment="c" fbc:charge="0" fbc:chemicalFormula="C31H56O5"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_12dgr141_e" name="1_2_Diacyl_sn_glycerol_ditetradec_7_enoyl_n_C141" compartment="e" fbc:charge="0" fbc:chemicalFormula="C31H56O5"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_12dgr160_c" name="1_2_Diacyl_sn_glycerol_dihexadecanoyl_n_C160" compartment="c" fbc:charge="0" fbc:chemicalFormula="C35H68O5"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_12dgr160_e" name="1_2_Diacyl_sn_glycerol_dihexadecanoyl_n_C160" compartment="e" fbc:charge="0" fbc:chemicalFormula="C35H68O5"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_12dgr161_c" name="1_2_Diacyl_sn_glycerol_dihexadec_9_enoyl_n_C161" compartment="c" fbc:charge="0" fbc:chemicalFormula="C35H64O5"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_12dgr161_e" name="1_2_Diacyl_sn_glycerol_dihexadec_9_enoyl_n_C161" compartment="e" fbc:charge="0" fbc:chemicalFormula="C35H64O5"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_12dgr180_c" name="1_2_Diacyl_sn_glycerol_dioctadecanoyl_n_C180" compartment="c" fbc:charge="0" fbc:chemicalFormula="C39H76O5"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_12dgr180_e" name="1_2_Diacyl_sn_glycerol_dioctadecanoyl_n_C180" compartment="e" fbc:charge="0" fbc:chemicalFormula="C39H76O5"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_12dgr181_c" name="1_2_Diacyl_sn_glycerol_dioctadec_11_enoyl_n_C181" compartment="c" fbc:charge="0" fbc:chemicalFormula="C39H72O5"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_12dgr181_e" name="1_2_Diacyl_sn_glycerol_dioctadec_11_enoyl_n_C181" compartment="e" fbc:charge="0" fbc:chemicalFormula="C39H72O5"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_13dpg_c" name="3_Phospho_D_glyceroyl_phosphate" compartment="c" fbc:charge="0" fbc:chemicalFormula="C3H4O10P2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_1agpe120_c" name="1_Acyl_sn_glycero_3_phosphoethanolamine_n_C120" compartment="c" fbc:charge="0" fbc:chemicalFormula="C17H36NO7P1"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_1agpe140_c" name="1_Acyl_sn_glycero_3_phosphoethanolamine_n_C140" compartment="c" fbc:charge="0" fbc:chemicalFormula="C19H40NO7P1"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_1agpe141_c" name="1_Acyl_sn_glycero_3_phosphoethanolamine_n_C141" compartment="c" fbc:charge="0" fbc:chemicalFormula="C19H38NO7P1"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_1agpe160_c" name="1_Acyl_sn_glycero_3_phosphoethanolamine_n_C160" compartment="c" fbc:charge="0" fbc:chemicalFormula="C21H44NO7P1"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_1agpe161_c" name="1_Acyl_sn_glycero_3_phosphoethanolamine_n_C161" compartment="c" fbc:charge="0" fbc:chemicalFormula="C21H42NO7P1"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_1agpe180_c" name="1_Acyl_sn_glycero_3_phosphoethanolamine_n_C180" compartment="c" fbc:charge="0" fbc:chemicalFormula="C23H48NO7P1"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_1agpe181_c" name="1_Acyl_sn_glycero_3_phosphoethanolamine_n_C181" compartment="c" fbc:charge="0" fbc:chemicalFormula="C23H46NO7P1"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_1agpg120_c" name="1_Acyl_sn_glycero_3_phosphoglycerol_n_C120" compartment="c" fbc:charge="0" fbc:chemicalFormula="C18H36O9P1"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_1agpg140_c" name="1_Acyl_sn_glycero_3_phosphoglycerol_n_C140" compartment="c" fbc:charge="0" fbc:chemicalFormula="C20H40O9P1"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_1agpg141_c" name="1_Acyl_sn_glycero_3_phosphoglycerol_n_C141" compartment="c" fbc:charge="0" fbc:chemicalFormula="C20H38O9P1"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_1agpg160_c" name="1_Acyl_sn_glycero_3_phosphoglycerol_n_C160" compartment="c" fbc:charge="0" fbc:chemicalFormula="C22H44O9P1"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_1agpg161_c" name="1_Acyl_sn_glycero_3_phosphoglycerol_n_C161" compartment="c" fbc:charge="0" fbc:chemicalFormula="C22H42O9P1"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_1agpg180_c" name="1_Acyl_sn_glycero_3_phosphoglycerol_n_C180" compartment="c" fbc:charge="0" fbc:chemicalFormula="C24H48O9P1"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_1agpg181_c" name="1_Acyl_sn_glycero_3_phosphoglycerol_n_C181" compartment="c" fbc:charge="0" fbc:chemicalFormula="C24H46O9P1"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_1ddecg3p_ap" name="1_dodecanoyl_sn_glycerol_3_phosphate" compartment="ap" fbc:charge="0" fbc:chemicalFormula="C15H29O7P1"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_1ddecg3p_c" name="1_dodecanoyl_sn_glycerol_3_phosphate" compartment="c" fbc:charge="0" fbc:chemicalFormula="C15H29O7P1"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_1hdec9eg3p_ap" name="1_hexadec_9_enoyl_sn_glycerol_3_phosphate" compartment="ap" fbc:charge="0" fbc:chemicalFormula="C19H35O7P1"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_1hdec9eg3p_c" name="1_hexadec_9_enoyl_sn_glycerol_3_phosphate" compartment="c" fbc:charge="0" fbc:chemicalFormula="C19H35O7P1"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_1hdecg3p_ap" name="1_hexadecanoyl_sn_glycerol_3_phosphate" compartment="ap" fbc:charge="0" fbc:chemicalFormula="C19H37O7P1"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_1hdecg3p_c" name="1_hexadecanoyl_sn_glycerol_3_phosphate" compartment="c" fbc:charge="0" fbc:chemicalFormula="C19H37O7P1"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_1odec11eg3p_ap" name="1_octadec_11_enoyl_sn_glycerol_3_phosphate" compartment="ap" fbc:charge="0" fbc:chemicalFormula="C21H39O7P1"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_1odec11eg3p_c" name="1_octadec_11_enoyl_sn_glycerol_3_phosphate" compartment="c" fbc:charge="0" fbc:chemicalFormula="C21H39O7P1"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_1odecg3p_ap" name="1_octadecanoyl_sn_glycerol_3_phosphate" compartment="ap" fbc:charge="0" fbc:chemicalFormula="C21H41O7P1"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_1odecg3p_c" name="1_octadecanoyl_sn_glycerol_3_phosphate" compartment="c" fbc:charge="0" fbc:chemicalFormula="C21H41O7P1"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_1pyr5c_c" name="1_Pyrroline_5_carboxylate" compartment="c" fbc:charge="0" fbc:chemicalFormula="C5H6NO2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_1tdec7eg3p_ap" name="1_tetradec_7_enoyl_sn_glycerol_3_phosphate" compartment="ap" fbc:charge="0" fbc:chemicalFormula="C17H31O7P1"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_1tdec7eg3p_c" name="1_tetradec_7_enoyl_sn_glycerol_3_phosphate" compartment="c" fbc:charge="0" fbc:chemicalFormula="C17H31O7P1"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_1tdecg3p_ap" name="1_tetradecanoyl_sn_glycerol_3_phosphate" compartment="ap" fbc:charge="0" fbc:chemicalFormula="C17H33O7P1"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_1tdecg3p_c" name="1_tetradecanoyl_sn_glycerol_3_phosphate" compartment="c" fbc:charge="0" fbc:chemicalFormula="C17H33O7P1"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_25aics_c" name="S_2_5_Amino_1_5_phospho_D_ribosyl_imidazole_4_carboxamidosuccinate" compartment="c" fbc:charge="0" fbc:chemicalFormula="C13H15N4O12P"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_2agpe120_c" name="2_Acyl_sn_glycero_3_phosphoethanolamine_n_C120" compartment="c" fbc:charge="0" fbc:chemicalFormula="C17H36NO7P1"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_2agpe140_c" name="2_Acyl_sn_glycero_3_phosphoethanolamine_n_C140" compartment="c" fbc:charge="0" fbc:chemicalFormula="C19H40NO7P1"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_2agpe141_c" name="2_Acyl_sn_glycero_3_phosphoethanolamine_n_C141" compartment="c" fbc:charge="0" fbc:chemicalFormula="C19H38NO7P1"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_2agpe160_c" name="2_Acyl_sn_glycero_3_phosphoethanolamine_n_C160" compartment="c" fbc:charge="0" fbc:chemicalFormula="C21H44NO7P1"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_2agpe161_c" name="2_Acyl_sn_glycero_3_phosphoethanolamine_n_C161" compartment="c" fbc:charge="0" fbc:chemicalFormula="C21H42NO7P1"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_2agpe180_c" name="2_Acyl_sn_glycero_3_phosphoethanolamine_n_C180" compartment="c" fbc:charge="0" fbc:chemicalFormula="C23H48NO7P1"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_2agpe181_c" name="2_Acyl_sn_glycero_3_phosphoethanolamine_n_C181" compartment="c" fbc:charge="0" fbc:chemicalFormula="C23H46NO7P1"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_2agpg120_c" name="2_Acyl_sn_glycero_3_phosphoglycerol_n_C120" compartment="c" fbc:charge="0" fbc:chemicalFormula="C18H36O9P1"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_2agpg140_c" name="2_Acyl_sn_glycero_3_phosphoglycerol_n_C140" compartment="c" fbc:charge="0" fbc:chemicalFormula="C20H40O9P1"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_2agpg141_c" name="2_Acyl_sn_glycero_3_phosphoglycerol_n_C141" compartment="c" fbc:charge="0" fbc:chemicalFormula="C20H38O9P1"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_2agpg160_c" name="2_Acyl_sn_glycero_3_phosphoglycerol_n_C160" compartment="c" fbc:charge="0" fbc:chemicalFormula="C22H44O9P1"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_2agpg161_c" name="2_Acyl_sn_glycero_3_phosphoglycerol_n_C161" compartment="c" fbc:charge="0" fbc:chemicalFormula="C22H42O9P1"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_2agpg180_c" name="2_Acyl_sn_glycero_3_phosphoglycerol_n_C180" compartment="c" fbc:charge="0" fbc:chemicalFormula="C24H48O9P1"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_2agpg181_c" name="2_Acyl_sn_glycero_3_phosphoglycerol_n_C181" compartment="c" fbc:charge="0" fbc:chemicalFormula="C24H46O9P1"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_2dda7p_c" name="2_Dehydro_3_deoxy_D_arabino_heptonate_7_phosphate" compartment="c" fbc:charge="0" fbc:chemicalFormula="C7H10O10P"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_2ddecg3p_c" name="2_dodecanoyl_sn_glycerol_3_phosphate" compartment="c" fbc:charge="0" fbc:chemicalFormula="C15H30O7P1"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_2dmmql8_c" name="2_Demethylmenaquinol_8" compartment="c" fbc:charge="0" fbc:chemicalFormula="C50H72O2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_2dr1p_c" name="2_Deoxy_D_ribose_1_phosphate" compartment="c" fbc:charge="0" fbc:chemicalFormula="C5H9O7P"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_2dr5p_c" name="2_Deoxy_D_ribose_5_phosphate" compartment="c" fbc:charge="0" fbc:chemicalFormula="C5H9O7P"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_2hdec9eg3p_c" name="2_hexadec_9_enoyl_sn_glycerol_3_phosphate" compartment="c" fbc:charge="0" fbc:chemicalFormula="C19H36O7P1"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_2hdecg3p_c" name="2_hexadecanoyl_sn_glycerol_3_phosphate" compartment="c" fbc:charge="0" fbc:chemicalFormula="C19H38O7P1"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_2mahmp_c" name="2_Methyl_4_amino_5_hydroxymethylpyrimidine_diphosphate" compartment="c" fbc:charge="0" fbc:chemicalFormula="C6H8N3O7P2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_2mbcoa_m" name="2-Methylbutanoyl-CoA" compartment="m" fbc:charge="0" fbc:chemicalFormula="C26H40N7O17P3S"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_2me4p_ap" name="2_C_methyl_D_erythritol_4_phosphate" compartment="ap" fbc:charge="0" fbc:chemicalFormula="C5H11O7P"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_2mecdp_ap" name="2_C_methyl_D_erythritol_2_4_cyclodiphosphate" compartment="ap" fbc:charge="0" fbc:chemicalFormula="C5H10O9P2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_2odec11eg3p_c" name="2_octadec_11_enoyl_sn_glycerol_3_phosphate" compartment="c" fbc:charge="0" fbc:chemicalFormula="C21H40O7P1"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_2odecg3p_c" name="2_octadecanoyl_sn_glycerol_3_phosphate" compartment="c" fbc:charge="0" fbc:chemicalFormula="C21H42O7P1"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_2ohph_m" name="2_Octaprenyl_6_hydroxyphenol" compartment="m" fbc:charge="0" fbc:chemicalFormula="C46H70O2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_2ombzl_m" name="2_Octaprenyl_6_methoxy_1_4_benzoquinol" compartment="m" fbc:charge="0" fbc:chemicalFormula="C47H72O3"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_2omhmbl_m" name="2_Octaprenyl_3_methyl_5_hydroxy_6_methoxy_1_4_benzoquinol" compartment="m" fbc:charge="0" fbc:chemicalFormula="C48H74O4"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_2ommbl_m" name="2_Octaprenyl_3_methyl_6_methoxy_1_4_benzoquinol" compartment="m" fbc:charge="0" fbc:chemicalFormula="C48H74O3"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_2omph_m" name="2_Octaprenyl_6_methoxyphenol" compartment="m" fbc:charge="0" fbc:chemicalFormula="C47H72O2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_2oph_m" name="2_Octaprenylphenol" compartment="m" fbc:charge="0" fbc:chemicalFormula="C46H70O"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_2p4c2me_ap" name="2_phospho_4_cytidine_5_diphospho_2_C_methyl_D_erythritol" compartment="ap" fbc:charge="0" fbc:chemicalFormula="C14H22N3O17P3"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_2pg_c" name="D_Glycerate_2_phosphate" compartment="c" fbc:charge="0" fbc:chemicalFormula="C3H4O7P"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_2tdec7eg3p_c" name="2_tetradec_7_enoyl_sn_glycerol_3_phosphate" compartment="c" fbc:charge="0" fbc:chemicalFormula="C17H32O7P1"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_2tdecg3p_c" name="2_tetradecanoyl_sn_glycerol_3_phosphate" compartment="c" fbc:charge="0" fbc:chemicalFormula="C17H34O7P1"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_35ccmp_c" name="3_5_Cyclic_CMP" compartment="c" fbc:charge="0" fbc:chemicalFormula="C9H11N3O7P"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_35cdamp_c" name="3_5_Cyclic_dAMP" compartment="c" fbc:charge="0" fbc:chemicalFormula="C10H11N5O5P"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_35cgmp_c" name="3_5_Cyclic_GMP" compartment="c" fbc:charge="0" fbc:chemicalFormula="C10H11N5O7P"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_35cgmp_e" name="3_5_Cyclic_GMP" compartment="e" fbc:charge="0" fbc:chemicalFormula="C10H11N5O7P"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_35cimp_c" name="3_5_Cyclic_IMP" compartment="c" fbc:charge="0" fbc:chemicalFormula="C10H10N4O7P"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_3dhq_c" name="3_Dehydroquinate" compartment="c" fbc:charge="0" fbc:chemicalFormula="C7H9O6"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_3dhsk_c" name="3_Dehydroshikimate" compartment="c" fbc:charge="0" fbc:chemicalFormula="C7H7O5"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_3dsphgn_c" name="3_Dehydrosphinganine" compartment="c" fbc:charge="0" fbc:chemicalFormula="C18H38NO2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_3haACP_ap" name="3R_3_Hydroxyacyl_acyl_carrier_protein" compartment="ap" fbc:charge="0" fbc:chemicalFormula="C15H27N2O9PRS"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_3hcddec5eACP_ap" name="R_3_hydroxy_cis_dodec_5_enoyl_acyl_carrier_protein" compartment="ap" fbc:charge="0" fbc:chemicalFormula="C23H41N2O9PRS"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_3hcmrs7eACP_ap" name="R_3_hydroxy_cis_myristol_7_eoyl_acyl_carrier_protein" compartment="ap" fbc:charge="0" fbc:chemicalFormula="C25H45N2O9PRS"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_3hcpalm9eACP_ap" name="R_3_hydroxy_cis_palm_9_eoyl_acyl_carrier_protein" compartment="ap" fbc:charge="0" fbc:chemicalFormula="C27H49N2O9PRS"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_3hcvac11eACP_ap" name="R_3_hydroxy_cis_vacc_11_enoyl_acyl_carrier_protein" compartment="ap" fbc:charge="0" fbc:chemicalFormula="C29H53N2O9PRS"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_3hddecACP_ap" name="R_3_Hydroxydodecanoyl_acyl_carrier_protein" compartment="ap" fbc:charge="0" fbc:chemicalFormula="C23H43N2O9PRS"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_3hdecACP_ap" name="R_3_Hydroxydecanoyl_acyl_carrier_protein" compartment="ap" fbc:charge="0" fbc:chemicalFormula="C21H39N2O9PRS"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_3hhexACP_ap" name="R_3_Hydroxyhexanoyl_acyl_carrier_protein" compartment="ap" fbc:charge="0" fbc:chemicalFormula="C17H31N2O9PRS"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_3hmp_c" name="3-Hydroxy-2-methylpropanoate" compartment="c" fbc:charge="0" fbc:chemicalFormula="C4H7O3"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_3hmrsACP_ap" name="R_3_Hydroxytetradecanoyl_acyl_carrier_protein" compartment="ap" fbc:charge="0" fbc:chemicalFormula="C25H47N2O9PRS"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_3hoctACP_ap" name="R_3_Hydroxyoctanoyl_acyl_carrier_protein" compartment="ap" fbc:charge="0" fbc:chemicalFormula="C19H35N2O9PRS"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_3hoctaACP_ap" name="R_3_Hydroxyoctadecanoyl_acyl_carrier_protein" compartment="ap" fbc:charge="0" fbc:chemicalFormula="C29H55N2O9PRS"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_3hpalmACP_ap" name="R_3_hydroxypalmitoyl_acyl_carrier_protein" compartment="ap" fbc:charge="0" fbc:chemicalFormula="C27H51N2O9PRS"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_3mob_c" name="3_Methyl_2_oxobutanoate" compartment="c" fbc:charge="0" fbc:chemicalFormula="C5H7O3"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_3mob_m" name="3_Methyl_2_oxobutanoate" compartment="m" fbc:charge="0" fbc:chemicalFormula="C5H7O3"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_3mop_c" name="S_3_Methyl_2_oxopentanoate" compartment="c" fbc:charge="0" fbc:chemicalFormula="C6H9O3"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_3mop_m" name="S_3_Methyl_2_oxopentanoate" compartment="m" fbc:charge="0" fbc:chemicalFormula="C6H9O3"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_3ocddec5eACP_ap" name="3_oxo_cis_dodec_5_enoyl_acyl_carrier_protein" compartment="ap" fbc:charge="0" fbc:chemicalFormula="C23H39N2O9PRS"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_3ocmrs7eACP_ap" name="3_oxo_cis_myristol_7_eoyl_acyl_carrier_protein" compartment="ap" fbc:charge="0" fbc:chemicalFormula="C25H43N2O9PRS"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_3ocpalm9eACP_ap" name="3_oxo_cis_palm_9_eoyl_acyl_carrier_protein" compartment="ap" fbc:charge="0" fbc:chemicalFormula="C27H47N2O9PRS"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_3ocvac11eACP_ap" name="3_oxo_cis_vacc_11_enoyl_acyl_carrier_protein" compartment="ap" fbc:charge="0" fbc:chemicalFormula="C29H51N2O9PRS"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_3odcoa_c" name="3_Oxodecanoyl_CoA" compartment="c" fbc:charge="0" fbc:chemicalFormula="C31H48N7O18P3S"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_3oddcoa_c" name="3_Oxododecanoyl_CoA" compartment="c" fbc:charge="0" fbc:chemicalFormula="C33H52N7O18P3S"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_3oddecACP_ap" name="3_Oxododecanoyl_acyl_carrier_protein" compartment="ap" fbc:charge="0" fbc:chemicalFormula="C23H41N2O9PRS"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_3odecACP_ap" name="3_Oxodecanoyl_acyl_carrier_protein" compartment="ap" fbc:charge="0" fbc:chemicalFormula="C21H37N2O9PRS"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_3ohcoa_c" name="3_Oxohexanoyl_CoA" compartment="c" fbc:charge="0" fbc:chemicalFormula="C27H40N7O18P3S"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_3ohdcoa_c" name="3_Oxohexadecanoyl_CoA" compartment="c" fbc:charge="0" fbc:chemicalFormula="C37H60N7O18P3S"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_3ohexACP_ap" name="3_Oxohexanoyl_acyl_carrier_protein" compartment="ap" fbc:charge="0" fbc:chemicalFormula="C17H29N2O9PRS"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_3omrsACP_ap" name="3_Oxotetradecanoyl_acyl_carrier_protein" compartment="ap" fbc:charge="0" fbc:chemicalFormula="C25H45N2O9PRS"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_3oocoa_c" name="3_Oxooctanoyl_CoA" compartment="c" fbc:charge="0" fbc:chemicalFormula="C29H44N7O18P3S"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_3ooctACP_ap" name="3_Oxooctanoyl_acyl_carrier_protein" compartment="ap" fbc:charge="0" fbc:chemicalFormula="C19H33N2O9PRS"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_3ooctdACP_ap" name="3_Oxooctadecanoyl_acyl_carrier_protein" compartment="ap" fbc:charge="0" fbc:chemicalFormula="C29H53N2O9PRS"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_3ohodcoa_c" name="3_Oxooctadecanoyl_CoA" compartment="c" fbc:charge="0" fbc:chemicalFormula="C39H64N7O18P3S"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_3opalmACP_ap" name="3_Oxohexadecanoyl_acyl_carrier_protein" compartment="ap" fbc:charge="0" fbc:chemicalFormula="C27H49N2O9PRS"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_3ophb_m" name="3_Octaprenyl_4_hydroxybenzoate" compartment="m" fbc:charge="0" fbc:chemicalFormula="C47H69O3"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_3otdcoa_c" name="3_Oxotetradecanoyl_CoA" compartment="c" fbc:charge="0" fbc:chemicalFormula="C35H56N7O18P3S"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_3pg_c" name="3_Phospho_D_glycerate" compartment="c" fbc:charge="0" fbc:chemicalFormula="C3H4O7P"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_3psme_c" name="5_O_1_Carboxyvinyl_3_phosphoshikimate" compartment="c" fbc:charge="0" fbc:chemicalFormula="C10H9O10P"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_4abut_c" name="4_Aminobutanoate" compartment="c" fbc:charge="0" fbc:chemicalFormula="C4H9NO2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_4abut_e" name="4_Aminobutanoate" compartment="e" fbc:charge="0" fbc:chemicalFormula="C4H9NO2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_4abz_c" name="4_Aminobenzoate" compartment="c" fbc:charge="0" fbc:chemicalFormula="C7H6NO2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_4abz_e" name="4_Aminobenzoate" compartment="e" fbc:charge="0" fbc:chemicalFormula="C7H6NO2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_4adcho_c" name="4_amino_4_deoxychorismate" compartment="c" fbc:charge="0" fbc:chemicalFormula="C10H10NO5"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_4ahmmp_c" name="4_Amino_5_hydroxymethyl_2_methylpyrimidine" compartment="c" fbc:charge="0" fbc:chemicalFormula="C6H9N3O"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_4ahmmp_e" name="4_Amino_5_hydroxymethyl_2_methylpyrimidine" compartment="e" fbc:charge="0" fbc:chemicalFormula="C6H9N3O"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_4ampm_c" name="4_Amino_2_methyl_5_phosphomethylpyrimidine" compartment="c" fbc:charge="0" fbc:chemicalFormula="C6H8N3O4P"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_4c2me_ap" name="4_cytidine_5_diphospho_2_C_methyl_D_erythritol" compartment="ap" fbc:charge="0" fbc:chemicalFormula="C14H23N3O14P2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_4hba_c" name="4_Hydroxy_benzyl_alcohol" compartment="c" fbc:charge="0" fbc:chemicalFormula="C7H8O2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_4hba_m" name="4_Hydroxy_benzyl_alcohol" compartment="m" fbc:charge="0" fbc:chemicalFormula="C7H8O2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_4hbz_c" name="4_Hydroxybenzoate" compartment="c" fbc:charge="0" fbc:chemicalFormula="C7H5O3"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_4hbz_m" name="4_Hydroxybenzoate" compartment="m" fbc:charge="0" fbc:chemicalFormula="C7H5O3"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_4mhetz_c" name="4_Methyl_5_2_hydroxyethyl_thiazole" compartment="c" fbc:charge="0" fbc:chemicalFormula="C6H9NOS"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_4mhetz_m" name="4_Methyl_5_2_hydroxyethyl_thiazole" compartment="m" fbc:charge="0" fbc:chemicalFormula="C6H9NOS"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_4mop_c" name="4_Methyl_2_oxopentanoate" compartment="c" fbc:charge="0" fbc:chemicalFormula="C6H9O3"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_4mop_m" name="4_Methyl_2_oxopentanoate" compartment="m" fbc:charge="0" fbc:chemicalFormula="C6H9O3"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_4mpetz_c" name="4_Methyl_5_2_phosphoethyl_thiazole" compartment="c" fbc:charge="0" fbc:chemicalFormula="C6H8NO4PS"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_4mpetz_m" name="4_Methyl_5_2_phosphoethyl_thiazole" compartment="m" fbc:charge="0" fbc:chemicalFormula="C6H8NO4PS"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_4ppan_c" name="D_4_Phosphopantothenate" compartment="c" fbc:charge="0" fbc:chemicalFormula="C9H15NO8P"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_4ppcys_c" name="N_R_4_Phosphopantothenoyl_L_cysteine" compartment="c" fbc:charge="0" fbc:chemicalFormula="C12H20N2O9PS"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_5aop_ap" name="5_Amino_4_oxopentanoate" compartment="ap" fbc:charge="0" fbc:chemicalFormula="C5H9NO3"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_5aop_c" name="5_Amino_4_oxopentanoate" compartment="c" fbc:charge="0" fbc:chemicalFormula="C5H9NO3"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_5aop_m" name="5_Amino_4_oxopentanoate" compartment="m" fbc:charge="0" fbc:chemicalFormula="C5H9NO3"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_5mta_c" name="5_Methylthioadenosine" compartment="c" fbc:charge="0" fbc:chemicalFormula="C11H15N5O3S"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_5mti_c" name="5-methyl thioinosine" compartment="c" fbc:charge="0.0" fbc:chemicalFormula="C11H14N4O4S"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_5mtr1p_c" name="5_methylthio_d_ribose_1_phosphate" compartment="c" fbc:charge="0" fbc:chemicalFormula="C6H13O7PS"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_6hmhpt_c" name="6_hydroxymethyl_dihydropterin" compartment="c" fbc:charge="0" fbc:chemicalFormula="C7H9N5O2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_6hmhpt_e" name="6_hydroxymethyl_dihydropterin" compartment="e" fbc:charge="0" fbc:chemicalFormula="C7H9N5O2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_6hmhptpp_c" name="6_hydroxymethyl_dihydropterin_pyrophosphate" compartment="c" fbc:charge="0" fbc:chemicalFormula="C7H8N5O8P2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_6pgc_c" name="6_Phospho_D_gluconate" compartment="c" fbc:charge="0" fbc:chemicalFormula="C6H10O10P"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_6pgl_c" name="6_phospho_D_glucono_1_5_lactone" compartment="c" fbc:charge="0" fbc:chemicalFormula="C6H9O9P"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_6pthp_c" name="6-Pyruvoyl-5,6,7,8-tetrahydropterin" compartment="c" fbc:charge="0" fbc:chemicalFormula="C9H11N5O3"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ACP_ap" name="acyl_carrier_protein" compartment="ap" fbc:charge="0" fbc:chemicalFormula="C11H21N2O7PRS"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_Asn_X_Ser_Thr_c" name="rotein-linke" compartment="c" fbc:charge="0"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_cysi__L_c" name="L-Cystine" compartment="c" fbc:charge="0" fbc:chemicalFormula="C6H12N2O4S2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_cysi__L_e" name="L-Cystine" compartment="e" fbc:charge="0" fbc:chemicalFormula="C6H12N2O4S2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_Rtotal_c" name="Lipid" compartment="c" fbc:charge="0"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_Rtotal_e" name="Lipid" compartment="e" fbc:charge="0"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_Rtotalcoa_c" name="LipidCoa" compartment="c" fbc:charge="0"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_Rtotalcoa_e" name="LipidCoa" compartment="e" fbc:charge="0"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_aacoa_c" name="Acetoacetyl_CoA" compartment="c" fbc:charge="0" fbc:chemicalFormula="C25H36N7O18P3S"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ac_c" name="Acetate" compartment="c" fbc:charge="0" fbc:chemicalFormula="C2H3O2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ac_e" name="Acetate" compartment="e" fbc:charge="0" fbc:chemicalFormula="C2H3O2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_acald_c" name="Acetaldehyde" compartment="c" fbc:charge="0" fbc:chemicalFormula="C2H4O"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_acald_e" name="Acetaldehyde" compartment="e" fbc:charge="0" fbc:chemicalFormula="C2H4O"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_accoa_ap" name="Acetyl_CoA" compartment="ap" fbc:charge="0" fbc:chemicalFormula="C23H34N7O17P3S"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_accoa_c" name="Acetyl_CoA" compartment="c" fbc:charge="0" fbc:chemicalFormula="C23H34N7O17P3S"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_accoa_m" name="Acetyl_CoA" compartment="m" fbc:charge="0" fbc:chemicalFormula="C23H34N7O17P3S"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_acgam1p_c" name="N_Acetyl_D_glucosamine_1_phosphate" compartment="c" fbc:charge="0" fbc:chemicalFormula="C8H14NO9P"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_acgam6p_c" name="N_Acetyl_D_glucosamine_6_phosphate" compartment="c" fbc:charge="0" fbc:chemicalFormula="C8H14NO9P"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_acglu_c" name="N_Acetyl_L_glutamate" compartment="c" fbc:charge="0" fbc:chemicalFormula="C7H9NO5"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_acgpail_c" name="N-Acetyl-D-glucosaminylphosphatidylinositol" compartment="c" fbc:charge="[]" fbc:chemicalFormula="[]"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_acon_C_c" name="cis_Aconitate" compartment="c" fbc:charge="0" fbc:chemicalFormula="C6H3O6"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_acon_C_m" name="cis_Aconitate" compartment="m" fbc:charge="0" fbc:chemicalFormula="C6H3O6"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_actACP_ap" name="Acetoacetyl_ACP" compartment="ap" fbc:charge="0" fbc:chemicalFormula="C15H25N2O9PRS"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ade_c" name="Adenine" compartment="c" fbc:charge="0" fbc:chemicalFormula="C5H5N5"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ade_e" name="Adenine" compartment="e" fbc:charge="0" fbc:chemicalFormula="C5H5N5"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_adn_c" name="Adenosine" compartment="c" fbc:charge="0" fbc:chemicalFormula="C10H13N5O4"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_adn_e" name="Adenosine" compartment="e" fbc:charge="0" fbc:chemicalFormula="C10H13N5O4"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_adp_ap" name="ADP" compartment="ap" fbc:charge="0" fbc:chemicalFormula="C10H12N5O10P2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_adp_c" name="ADP" compartment="c" fbc:charge="0" fbc:chemicalFormula="C10H12N5O10P2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_adp_m" name="ADP" compartment="m" fbc:charge="0" fbc:chemicalFormula="C10H12N5O10P2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ahcys_c" name="S_Adenosyl_L_homocysteine" compartment="c" fbc:charge="0" fbc:chemicalFormula="C14H20N6O5S"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ahcys_m" name="S_Adenosyl_L_homocysteine" compartment="m" fbc:charge="0" fbc:chemicalFormula="C14H20N6O5S"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ahdt_c" name="2_Amino_4_hydroxy_6_erythro_1_2_3_trihydroxypropyl_dihydropteridine_triphosphate" compartment="c" fbc:charge="0" fbc:chemicalFormula="C9H12N5O13P3"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_aicar_c" name="5_Amino_1_5_Phospho_D_ribosyl_imidazole_4_carboxamide" compartment="c" fbc:charge="0" fbc:chemicalFormula="C9H13N4O8P"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_akg_c" name="2_Oxoglutarate" compartment="c" fbc:charge="0" fbc:chemicalFormula="C5H4O5"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_akg_e" name="2_Oxoglutarate" compartment="e" fbc:charge="0" fbc:chemicalFormula="C5H4O5"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_akg_m" name="2_Oxoglutarate" compartment="m" fbc:charge="0" fbc:chemicalFormula="C5H4O5"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ala__L_c" name="L_Alanine" compartment="c" fbc:charge="0" fbc:chemicalFormula="C3H7NO2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ala__L_e" name="L_Alanine" compartment="e" fbc:charge="0" fbc:chemicalFormula="C3H7NO2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ala__L_m" name="L_Alanine" compartment="m" fbc:charge="0" fbc:chemicalFormula="C3H7NO2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_alatrna_c" name="L_Alanyl_tRNA_Ala" compartment="c" fbc:charge="0" fbc:chemicalFormula="C3H6NOR"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_amet_c" name="S_Adenosyl_L_methionine" compartment="c" fbc:charge="0" fbc:chemicalFormula="C15H23N6O5S"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_amet_e" name="S_Adenosyl_L_methionine" compartment="e" fbc:charge="0" fbc:chemicalFormula="C15H23N6O5S"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_amet_m" name="S_Adenosyl_L_methionine" compartment="m" fbc:charge="0" fbc:chemicalFormula="C15H23N6O5S"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ametam_c" name="S_Adenosylmethioninamine" compartment="c" fbc:charge="0" fbc:chemicalFormula="C14H24N6O3S"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_amp_ap" name="AMP" compartment="ap" fbc:charge="0" fbc:chemicalFormula="C10H12N5O7P"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_amp_c" name="AMP" compartment="c" fbc:charge="0" fbc:chemicalFormula="C10H12N5O7P"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_anth_c" name="Anthranilate" compartment="c" fbc:charge="0" fbc:chemicalFormula="C7H6NO2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_apg120_c" name="acyl_phosphatidylglycerol_n_C120" compartment="c" fbc:charge="0" fbc:chemicalFormula="C42H80O11P"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_apg140_c" name="acyl_phosphatidylglycerol_n_C140" compartment="c" fbc:charge="0" fbc:chemicalFormula="C48H92O11P"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_apg141_c" name="acyl_phosphatidylglycerol_n_C141" compartment="c" fbc:charge="0" fbc:chemicalFormula="C48H86O11P"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_apg160_c" name="acyl_phosphatidylglycerol_n_C160" compartment="c" fbc:charge="0" fbc:chemicalFormula="C54H104O11P"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_apg161_c" name="acyl_phosphatidylglycerol_n_C161" compartment="c" fbc:charge="0" fbc:chemicalFormula="C54H98O11P"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_apg180_c" name="acyl_phosphatidylglycerol_n_C180" compartment="c" fbc:charge="0" fbc:chemicalFormula="C60H116O11P"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_apg181_c" name="acyl_phosphatidylglycerol_n_C181" compartment="c" fbc:charge="0" fbc:chemicalFormula="C60H110O11P"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_apoACP_c" name="apoprotein_acyl_carrier_protein" compartment="c" fbc:charge="0" fbc:chemicalFormula="RHO"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_arg__L_c" name="L_Arginine" compartment="c" fbc:charge="0" fbc:chemicalFormula="C6H15N4O2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_arg__L_e" name="L_Arginine" compartment="e" fbc:charge="0" fbc:chemicalFormula="C6H15N4O2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_asn__L_c" name="L_Asparagine" compartment="c" fbc:charge="0" fbc:chemicalFormula="C4H8N2O3"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_asn__L_e" name="L_Asparagine" compartment="e" fbc:charge="0" fbc:chemicalFormula="C4H8N2O3"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_asp__L_c" name="L_Aspartate" compartment="c" fbc:charge="0" fbc:chemicalFormula="C4H6NO4"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_asp__L_e" name="L_Aspartate" compartment="e" fbc:charge="0" fbc:chemicalFormula="C4H6NO4"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_asp__L_m" name="L_Aspartate" compartment="m" fbc:charge="0" fbc:chemicalFormula="C4H6NO4"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_atp_ap" name="ATP" compartment="ap" fbc:charge="0" fbc:chemicalFormula="C10H12N5O13P3"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_atp_c" name="ATP" compartment="c" fbc:charge="0" fbc:chemicalFormula="C10H12N5O13P3"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_atp_m" name="ATP" compartment="m" fbc:charge="0" fbc:chemicalFormula="C10H12N5O13P3"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_btcoa_c" name="Butanoyl_CoA" compartment="c" fbc:charge="0" fbc:chemicalFormula="C25H38N7O17P3S"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_but2eACP_ap" name="But_2_enoyl_acyl_carrier_protein" compartment="ap" fbc:charge="0" fbc:chemicalFormula="C15H25N2O8PRS"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_butACP_ap" name="Butyryl_ACP_n_C40ACP" compartment="ap" fbc:charge="0" fbc:chemicalFormula="C15H27N2O8PRS"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_camp_c" name="cAMP" compartment="c" fbc:charge="0" fbc:chemicalFormula="C10H11N5O6P"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_camp_e" name="cAMP" compartment="e" fbc:charge="0" fbc:chemicalFormula="C10H11N5O6P"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_cbasp_c" name="N_Carbamoyl_L_aspartate" compartment="c" fbc:charge="0" fbc:chemicalFormula="C5H6N2O5"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_cbp_c" name="Carbamoyl_phosphate" compartment="c" fbc:charge="0" fbc:chemicalFormula="CH2NO5P"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_cddec5eACP_ap" name="cis_dodec_5_enoyl_acyl_carrier_protein_n_C121" compartment="ap" fbc:charge="0" fbc:chemicalFormula="C23H41N2O8PRS"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_cdec3eACP_ap" name="cis_dec_3_enoyl_acyl_carrier_protein_n_C101" compartment="ap" fbc:charge="0" fbc:chemicalFormula="C21H37N2O8PRS"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_cdp_c" name="CDP" compartment="c" fbc:charge="0" fbc:chemicalFormula="C9H12N3O11P2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_cdpchol_c" name="CDPcholine" compartment="c" fbc:charge="0" fbc:chemicalFormula="C14H25N4O11P2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_cdpdag_c" name="CDP-Diacylglycerol" compartment="c" fbc:charge="[]" fbc:chemicalFormula="[]"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_cdpdag_e" name="CDP-Diacylglycerol" compartment="e" fbc:charge="[]" fbc:chemicalFormula="[]"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_cdpdddecg_c" name="CDP_1_2_didodecanoylglycerol" compartment="c" fbc:charge="0" fbc:chemicalFormula="C36H63N3O15P2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_cdpdddecg_e" name="CDP_1_2_didodecanoylglycerol" compartment="e" fbc:charge="0" fbc:chemicalFormula="C36H63N3O15P2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_cdpdhdec9eg_c" name="CDP_1_2_dihexadec_9_enoylglycerol" compartment="c" fbc:charge="0" fbc:chemicalFormula="C44H75N3O15P2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_cdpdhdec9eg_e" name="CDP_1_2_dihexadec_9_enoylglycerol" compartment="e" fbc:charge="0" fbc:chemicalFormula="C44H75N3O15P2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_cdpdhdecg_c" name="CDP_1_2_dihexadecanoylglycerol" compartment="c" fbc:charge="0" fbc:chemicalFormula="C44H79N3O15P2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_cdpdhdecg_e" name="CDP_1_2_dihexadecanoylglycerol" compartment="e" fbc:charge="0" fbc:chemicalFormula="C44H79N3O15P2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_cdpdodec11eg_c" name="CDP_1_2_dioctadec_11_enoylglycerol" compartment="c" fbc:charge="0" fbc:chemicalFormula="C48H83N3O15P2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_cdpdodec11eg_e" name="CDP_1_2_dioctadec_11_enoylglycerol" compartment="e" fbc:charge="0" fbc:chemicalFormula="C48H83N3O15P2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_cdpdodecg_c" name="CDP_1_2_dioctadecanoylglycerol" compartment="c" fbc:charge="0" fbc:chemicalFormula="C48H87N3O15P2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_cdpdodecg_e" name="CDP_1_2_dioctadecanoylglycerol" compartment="e" fbc:charge="0" fbc:chemicalFormula="C48H87N3O15P2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_cdpdtdec7eg_c" name="CDP_1_2_ditetradec_7_enoylglycerol" compartment="c" fbc:charge="0" fbc:chemicalFormula="C40H67N3O15P2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_cdpdtdec7eg_e" name="CDP_1_2_ditetradec_7_enoylglycerol" compartment="e" fbc:charge="0" fbc:chemicalFormula="C40H67N3O15P2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_cdpdtdecg_c" name="CDP_1_2_ditetradecanoylglycerol" compartment="c" fbc:charge="0" fbc:chemicalFormula="C40H71N3O15P2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_cdpdtdecg_e" name="CDP_1_2_ditetradecanoylglycerol" compartment="e" fbc:charge="0" fbc:chemicalFormula="C40H71N3O15P2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_cdpea_c" name="CDPethanolamine" compartment="c" fbc:charge="0" fbc:chemicalFormula="C11H19N4O11P2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_chol_c" name="Choline" compartment="c" fbc:charge="0" fbc:chemicalFormula="C5H14NO"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_chol_e" name="Choline" compartment="e" fbc:charge="0" fbc:chemicalFormula="C5H14NO"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_cholp_c" name="Choline_phosphate" compartment="c" fbc:charge="0" fbc:chemicalFormula="C5H13NO4P"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_chor_c" name="chorismate" compartment="c" fbc:charge="0" fbc:chemicalFormula="C10H8O6"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_chsterol_c" name="holesterol" compartment="c" fbc:charge="0" fbc:chemicalFormula="C27H46O"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_chsterol_e" name="holesterol" compartment="e" fbc:charge="0" fbc:chemicalFormula="C27H46O"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_cit_c" name="Citrate" compartment="c" fbc:charge="0" fbc:chemicalFormula="C6H5O7"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_cit_e" name="Citrate" compartment="e" fbc:charge="0" fbc:chemicalFormula="C6H5O7"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_cit_m" name="Citrate" compartment="m" fbc:charge="0" fbc:chemicalFormula="C6H5O7"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_clpn120_c" name="cardiolipin_tetradodecanoyl_n_C120" compartment="c" fbc:charge="0" fbc:chemicalFormula="C57H108O17P2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_clpn140_c" name="cardiolipin_tetratetradecanoyl_n_C140" compartment="c" fbc:charge="0" fbc:chemicalFormula="C65H124O17P2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_clpn141_c" name="cardiolipin_tetratetradec_7_enoyl_n_C141" compartment="c" fbc:charge="0" fbc:chemicalFormula="C65H116O17P2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_clpn160_c" name="cardiolipin_tetrahexadecanoyl_n_C160" compartment="c" fbc:charge="0" fbc:chemicalFormula="C73H140O17P2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_clpn161_c" name="cardiolipin_tetrahexadec_9_enoyl_n_C161" compartment="c" fbc:charge="0" fbc:chemicalFormula="C73H132O17P2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_clpn180_c" name="cardiolipin_tetraoctadecanoyl_n_C180" compartment="c" fbc:charge="0" fbc:chemicalFormula="C81H156O17P2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_clpn181_c" name="cardiolipin_tetraoctadec_11_enoyl_n_C181" compartment="c" fbc:charge="0" fbc:chemicalFormula="C81H148O17P2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_cmp_ap" name="CMP" compartment="ap" fbc:charge="0" fbc:chemicalFormula="C9H12N3O8P"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_cmp_c" name="CMP" compartment="c" fbc:charge="0" fbc:chemicalFormula="C9H12N3O8P"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_co2_ap" name="CO2" compartment="ap" fbc:charge="0" fbc:chemicalFormula="CO2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_co2_c" name="CO2" compartment="c" fbc:charge="0" fbc:chemicalFormula="CO2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_co2_e" name="CO2" compartment="e" fbc:charge="0" fbc:chemicalFormula="CO2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_co2_m" name="CO2" compartment="m" fbc:charge="0" fbc:chemicalFormula="CO2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_coa_ap" name="Coenzyme_A" compartment="ap" fbc:charge="0" fbc:chemicalFormula="C21H32N7O16P3S"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_coa_c" name="Coenzyme_A" compartment="c" fbc:charge="0" fbc:chemicalFormula="C21H32N7O16P3S"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_coa_m" name="Coenzyme_A" compartment="m" fbc:charge="0" fbc:chemicalFormula="C21H32N7O16P3S"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_cpppg3_ap" name="Coproporphyrinogen_III" compartment="ap" fbc:charge="0" fbc:chemicalFormula="C36H40N4O8"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_cpppg3_c" name="Coproporphyrinogen_III" compartment="c" fbc:charge="0" fbc:chemicalFormula="C36H40N4O8"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_cpppg3_m" name="Coproporphyrinogen_III" compartment="m" fbc:charge="0" fbc:chemicalFormula="C36H40N4O8"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_crm_c" name="ceramide" compartment="c" fbc:charge="[0]" fbc:chemicalFormula="['C18H36NO2RCO']"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ctp_ap" name="CTP" compartment="ap" fbc:charge="0" fbc:chemicalFormula="C9H12N3O14P3"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ctp_c" name="CTP" compartment="c" fbc:charge="0" fbc:chemicalFormula="C9H12N3O14P3"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_cys__L_c" name="L_Cysteine" compartment="c" fbc:charge="0" fbc:chemicalFormula="C3H7NO2S"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_cys__L_e" name="L_Cysteine" compartment="e" fbc:charge="0" fbc:chemicalFormula="C3H7NO2S"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_cys__L_m" name="L_Cysteine" compartment="m" fbc:charge="0" fbc:chemicalFormula="C3H7NO2S"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_cystrna_c" name="L_Cysteinyl_tRNA_Cys" compartment="c" fbc:charge="0" fbc:chemicalFormula="C3H6NOSR"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_dad_2_c" name="Deoxyadenosine" compartment="c" fbc:charge="0" fbc:chemicalFormula="C10H13N5O3"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_dad_2_e" name="Deoxyadenosine" compartment="e" fbc:charge="0" fbc:chemicalFormula="C10H13N5O3"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_dadp_c" name="dADP" compartment="c" fbc:charge="0" fbc:chemicalFormula="C10H12N5O9P2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_dag_c" name="diacylglycerols (total)" compartment="c" fbc:charge="[]" fbc:chemicalFormula="[]"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_dag_e" name="diacylglycerols (total)" compartment="e" fbc:charge="[]" fbc:chemicalFormula="[]"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_damp_c" name="dAMP" compartment="c" fbc:charge="0" fbc:chemicalFormula="C10H12N5O6P"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_datp_c" name="dATP" compartment="c" fbc:charge="0" fbc:chemicalFormula="C10H12N5O12P3"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_dcaACP_ap" name="Decanoyl_ACP_n_C100ACP" compartment="ap" fbc:charge="0" fbc:chemicalFormula="C21H39N2O8PRS"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_dca_ap" name="Decanoate_n_C100" compartment="ap" fbc:charge="0" fbc:chemicalFormula="C10H19O2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_dca_c" name="Decanoate_n_C100" compartment="c" fbc:charge="0" fbc:chemicalFormula="C10H19O2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_dca_e" name="Decanoate_n_C100" compartment="e" fbc:charge="0" fbc:chemicalFormula="C10H19O2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_dcacoa_ap" name="Decanoyl_CoA_n_C100CoA" compartment="ap" fbc:charge="0" fbc:chemicalFormula="C31H50N7O17P3S"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_dcacoa_c" name="Decanoyl_CoA_n_C100CoA" compartment="c" fbc:charge="0" fbc:chemicalFormula="C31H50N7O17P3S"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_dcacoa_e" name="Decanoyl_CoA_n_C100CoA" compartment="e" fbc:charge="0" fbc:chemicalFormula="C31H50N7O17P3S"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_dcamp_c" name="N6_1_2_Dicarboxyethyl_AMP" compartment="c" fbc:charge="0" fbc:chemicalFormula="C14H14N5O11P"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_dcdp_c" name="dCDP" compartment="c" fbc:charge="0" fbc:chemicalFormula="C9H12N3O10P2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_dctp_c" name="dCTP" compartment="c" fbc:charge="0" fbc:chemicalFormula="C9H12N3O13P3"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ddcaACP_ap" name="Dodecanoyl_ACP_n_C120ACP" compartment="ap" fbc:charge="0" fbc:chemicalFormula="C23H43N2O8PRS"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ddca_ap" name="Dodecanoate_n_C120" compartment="ap" fbc:charge="0" fbc:chemicalFormula="C12H23O2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ddca_c" name="Dodecanoate_n_C120" compartment="c" fbc:charge="0" fbc:chemicalFormula="C12H23O2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ddca_e" name="Dodecanoate_n_C120" compartment="e" fbc:charge="0" fbc:chemicalFormula="C12H23O2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ddcacoa_ap" name="Dodecanoyl_CoA_n_C120CoA" compartment="ap" fbc:charge="0" fbc:chemicalFormula="C33H54N7O17P3S"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ddcacoa_c" name="Dodecanoyl_CoA_n_C120CoA" compartment="c" fbc:charge="0" fbc:chemicalFormula="C33H54N7O17P3S"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ddcacoa_e" name="Dodecanoyl_CoA_n_C120CoA" compartment="e" fbc:charge="0" fbc:chemicalFormula="C33H54N7O17P3S"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_dgdp_c" name="dGDP" compartment="c" fbc:charge="0" fbc:chemicalFormula="C10H12N5O10P2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_dgmp_c" name="dGMP" compartment="c" fbc:charge="0" fbc:chemicalFormula="C10H12N5O7P"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_dgsn_c" name="Deoxyguanosine" compartment="c" fbc:charge="0" fbc:chemicalFormula="C10H13N5O4"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_dgsn_e" name="Deoxyguanosine" compartment="e" fbc:charge="0" fbc:chemicalFormula="C10H13N5O4"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_dgtp_c" name="dGTP" compartment="c" fbc:charge="0" fbc:chemicalFormula="C10H12N5O13P3"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_dhap_ap" name="Dihydroxyacetone_phosphate" compartment="ap" fbc:charge="0" fbc:chemicalFormula="C3H5O6P"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_dhap_c" name="Dihydroxyacetone_phosphate" compartment="c" fbc:charge="0" fbc:chemicalFormula="C3H5O6P"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_dhap_m" name="Dihydroxyacetone_phosphate" compartment="m" fbc:charge="0" fbc:chemicalFormula="C3H5O6P"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_dhcrm_c" name="Dihydroceramide" compartment="c" fbc:charge="[0]" fbc:chemicalFormula="['C18H38NO2RCO']"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_dhf_c" name="7_8_Dihydrofolate" compartment="c" fbc:charge="0" fbc:chemicalFormula="C19H19N7O6"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_dhnpt_c" name="Dihydroneopterin" compartment="c" fbc:charge="0" fbc:chemicalFormula="C9H13N5O4"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_dhor__S_c" name="S_Dihydroorotate" compartment="c" fbc:charge="0" fbc:chemicalFormula="C5H5N2O4"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_dhor__S_m" name="S_Dihydroorotate" compartment="m" fbc:charge="0" fbc:chemicalFormula="C5H5N2O4"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_dhpt_c" name="Dihydropteroate" compartment="c" fbc:charge="0" fbc:chemicalFormula="C14H13N6O3"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_dimp_c" name="dIMP" compartment="c" fbc:charge="0" fbc:chemicalFormula="C10H11N4O7P"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_din_c" name="Deoxyinosine" compartment="c" fbc:charge="0" fbc:chemicalFormula="C10H12N4O4"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_din_e" name="Deoxyinosine" compartment="e" fbc:charge="0" fbc:chemicalFormula="C10H12N4O4"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ditp_c" name="dITP" compartment="c" fbc:charge="0" fbc:chemicalFormula="C10H11N4O13P3"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_dmpp_ap" name="Dimethylallyl_diphosphate" compartment="ap" fbc:charge="0" fbc:chemicalFormula="C5H9O7P2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_dmpp_c" name="Dimethylallyl_diphosphate" compartment="c" fbc:charge="0" fbc:chemicalFormula="C5H9O7P2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_dnad_c" name="Deamino_NAD" compartment="c" fbc:charge="0" fbc:chemicalFormula="C21H24N6O15P2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_doldp__L_c" name="Dolichol diphosphate" compartment="c" fbc:charge="0"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_dolichol_c" name="Dolichol" compartment="c" fbc:charge="0" fbc:chemicalFormula="C15H28O"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_dolmanp__L_c" name="Dolichyl phosphate D-mannose" compartment="c" fbc:charge="0"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_dolp_c" name="Dolichol_phosphate" compartment="c" fbc:charge="0" fbc:chemicalFormula="C15H27O4P"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_dpcoa_ap" name="Dephospho_CoA" compartment="ap" fbc:charge="0" fbc:chemicalFormula="C21H33N7O13P2S"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_dpcoa_c" name="Dephospho_CoA" compartment="c" fbc:charge="0" fbc:chemicalFormula="C21H33N7O13P2S"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_dsbaox_e" name="periplasmic_protein_disulfide_isomerase_I_oxidized" compartment="e" fbc:charge="0" fbc:chemicalFormula="X"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_dsbard_e" name="periplasmic_protein_disulfide_isomerase_I_reduced" compartment="e" fbc:charge="0" fbc:chemicalFormula="XH2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_dsbcox_c" name="protein_disulfide_isomerase_II_oxidized" compartment="c" fbc:charge="0" fbc:chemicalFormula="X"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_dsbcrd_c" name="protein_disulfide_isomerase_II_reduced" compartment="c" fbc:charge="0" fbc:chemicalFormula="XH2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_dsbgox_c" name="periplasmic_disulfide_isomerasethiol_disulphide_oxidase_oxidized" compartment="c" fbc:charge="0" fbc:chemicalFormula="X"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_dsbgrd_c" name="periplasmic_disulfide_isomerasethiol_disulphide_oxidase_reduced" compartment="c" fbc:charge="0" fbc:chemicalFormula="XH2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_dtdp_c" name="dTDP" compartment="c" fbc:charge="0" fbc:chemicalFormula="C10H13N2O11P2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_dtmp_c" name="dTMP" compartment="c" fbc:charge="0" fbc:chemicalFormula="C10H13N2O8P"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_dttp_c" name="dTTP" compartment="c" fbc:charge="0" fbc:chemicalFormula="C10H13N2O14P3"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_dudp_c" name="dUDP" compartment="c" fbc:charge="0" fbc:chemicalFormula="C9H11N2O11P2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_dump_c" name="dUMP" compartment="c" fbc:charge="0" fbc:chemicalFormula="C9H11N2O8P"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_duri_c" name="Deoxyuridine" compartment="c" fbc:charge="0" fbc:chemicalFormula="C9H12N2O5"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_dutp_c" name="dUTP" compartment="c" fbc:charge="0" fbc:chemicalFormula="C9H11N2O14P3"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_dxyl5p_ap" name="1_deoxy_D_xylulose_5_phosphate" compartment="ap" fbc:charge="0" fbc:chemicalFormula="C5H9O7P"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_dxyl5p_c" name="1_deoxy_D_xylulose_5_phosphate" compartment="c" fbc:charge="0" fbc:chemicalFormula="C5H9O7P"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_dxyl5p_m" name="1_deoxy_D_xylulose_5_phosphate" compartment="m" fbc:charge="0" fbc:chemicalFormula="C5H9O7P"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_e4p_c" name="D_Erythrose_4_phosphate" compartment="c" fbc:charge="0" fbc:chemicalFormula="C4H7O7P"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_etha_c" name="Ethanolamine" compartment="c" fbc:charge="0" fbc:chemicalFormula="C2H8NO"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_etha_e" name="Ethanolamine" compartment="e" fbc:charge="0" fbc:chemicalFormula="C2H8NO"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ethamp_c" name="Ethanolamine_phosphate" compartment="c" fbc:charge="0" fbc:chemicalFormula="C2H7NO4P"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_f6p_c" name="D_Fructose_6_phosphate" compartment="c" fbc:charge="0" fbc:chemicalFormula="C6H11O9P"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_fad_c" name="Flavin_adenine_dinucleotide_oxidized" compartment="c" fbc:charge="0" fbc:chemicalFormula="C27H31N9O15P2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_fdp_c" name="D_Fructose_1_6_bisphosphate" compartment="c" fbc:charge="0" fbc:chemicalFormula="C6H10O12P2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_fe2_ap" name="Fe2" compartment="ap" fbc:charge="0" fbc:chemicalFormula="Fe"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_fe2_c" name="Fe2" compartment="c" fbc:charge="0" fbc:chemicalFormula="Fe"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_fe2_e" name="Fe2" compartment="e" fbc:charge="0" fbc:chemicalFormula="Fe"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_fe3_c" name="Fe3" compartment="c" fbc:charge="0" fbc:chemicalFormula="Fe"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ficytc_m" name="Ferricytochrome_c" compartment="m" fbc:charge="0" fbc:chemicalFormula="C42H52FeN8O6S2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_fldox_ap" name="flavodoxin_oxidized" compartment="ap" fbc:charge="0" fbc:chemicalFormula="X"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_fldrd_ap" name="flavodoxin_reduced" compartment="ap" fbc:charge="0" fbc:chemicalFormula="XH2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_fmet_c" name="N_Formyl_L_methionine" compartment="c" fbc:charge="0" fbc:chemicalFormula="C6H10NO3S"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_fmettrna_c" name="N_Formylmethionyl_tRNA" compartment="c" fbc:charge="0" fbc:chemicalFormula="C6H9NO2SR"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_fmn_c" name="FMN" compartment="c" fbc:charge="0" fbc:chemicalFormula="C17H19N4O9P"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_focytc_m" name="Ferrocytochrome_c" compartment="m" fbc:charge="0" fbc:chemicalFormula="C42H53FeN8O6S2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_fol_e" name="olate" compartment="e" fbc:charge="0" fbc:chemicalFormula="C19H18N7O6"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_for_c" name="Formate" compartment="c" fbc:charge="0" fbc:chemicalFormula="CH1O2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_for_e" name="Formate" compartment="e" fbc:charge="0" fbc:chemicalFormula="CH1O2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_frdp_c" name="Farnesyl_diphosphate" compartment="c" fbc:charge="0" fbc:chemicalFormula="C15H25O7P2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_fru_c" name="D_Fructose" compartment="c" fbc:charge="0" fbc:chemicalFormula="C6H12O6"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_fru_e" name="D_Fructose" compartment="e" fbc:charge="0" fbc:chemicalFormula="C6H12O6"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_fum_c" name="Fumarate" compartment="c" fbc:charge="0" fbc:chemicalFormula="C4H2O4"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_fum_e" name="Fumarate" compartment="e" fbc:charge="0" fbc:chemicalFormula="C4H2O4"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_fum_m" name="Fumarate" compartment="m" fbc:charge="0" fbc:chemicalFormula="C4H2O4"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_g1p_c" name="D_Glucose_1_phosphate" compartment="c" fbc:charge="0" fbc:chemicalFormula="C6H11O9P"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_g3m8masn_c" name="alpha-D-Glucosyl)3-(alpha-D-mannosyl)8-beta-D-mannosyl-diacetylchitobiosyl-L-asparagine" compartment="c" fbc:charge="0"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_g3m8mpdol__L_c" name="alpha-D-Glucosyl)3-(alpha-D-mannosyl)8-beta-D-mannosyl-diacetylchitobiosyldiphosphodolichol" compartment="c" fbc:charge="0"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_g3p_ap" name="Glyceraldehyde_3_phosphate" compartment="ap" fbc:charge="0" fbc:chemicalFormula="C3H5O6P"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_g3p_c" name="Glyceraldehyde_3_phosphate" compartment="c" fbc:charge="0" fbc:chemicalFormula="C3H5O6P"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_g3pc_c" name="sn_Glycero_3_phosphocholine" compartment="c" fbc:charge="0" fbc:chemicalFormula="C8H20NO6P"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_g3pe_c" name="sn_Glycero_3_phosphoethanolamine" compartment="c" fbc:charge="0" fbc:chemicalFormula="C5H14NO6P"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_g3pg_c" name="Glycerophosphoglycerol" compartment="c" fbc:charge="0" fbc:chemicalFormula="C6H14O8P"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_g3pi_c" name="sn_Glycero_3_phospho_1_inositol" compartment="c" fbc:charge="0" fbc:chemicalFormula="C9H18O11P"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_g3ps_c" name="Glycerophosphoserine" compartment="c" fbc:charge="0" fbc:chemicalFormula="C6H13NO8P"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_g6p_c" name="D_Glucose_6_phosphate" compartment="c" fbc:charge="0" fbc:chemicalFormula="C6H11O9P"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_gacpail_c" name="Glucosaminyl-acylphosphatidylinositol" compartment="c" fbc:charge="[0]" fbc:chemicalFormula="[]"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_gam6p_c" name="D_Glucosamine_6_phosphate" compartment="c" fbc:charge="0" fbc:chemicalFormula="C6H13NO8P"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_gam6p_e" name="D_Glucosamine_6_phosphate" compartment="e" fbc:charge="0" fbc:chemicalFormula="C6H13NO8P"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_gam_c" name="D_Glucosamine" compartment="c" fbc:charge="0" fbc:chemicalFormula="C6H14NO5"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_gam_e" name="D_Glucosamine" compartment="e" fbc:charge="0" fbc:chemicalFormula="C6H14NO5"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_gchola_c" name="lycocholate" compartment="c" fbc:charge="0" fbc:chemicalFormula="C26H43NO6"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_gchola_e" name="lycocholate" compartment="e" fbc:charge="0" fbc:chemicalFormula="C26H43NO6"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_gdp_c" name="GDP" compartment="c" fbc:charge="0" fbc:chemicalFormula="C10H12N5O11P2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_gdp_m" name="GDP" compartment="m" fbc:charge="0" fbc:chemicalFormula="C10H12N5O11P2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_gdpddman_c" name="GDP_4_dehydro_6_deoxy_D_mannose" compartment="c" fbc:charge="0" fbc:chemicalFormula="C16H21N5O15P2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_gdpfuc_c" name="GDP_L_fucose" compartment="c" fbc:charge="0" fbc:chemicalFormula="C16H23N5O15P2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_gdpmann_c" name="GDP_D_mannose" compartment="c" fbc:charge="0" fbc:chemicalFormula="C16H23N5O16P2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ggdp_c" name="Geranylgeranyl diphosphate" compartment="c" fbc:charge="0"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_glc__D_c" name="D_Glucose" compartment="c" fbc:charge="0" fbc:chemicalFormula="C6H12O6"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_glc__D_e" name="D_Glucose" compartment="e" fbc:charge="0" fbc:chemicalFormula="C6H12O6"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_glcn_c" name="D_Gluconate" compartment="c" fbc:charge="0" fbc:chemicalFormula="C6H11O7"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_gln__L_c" name="L_Glutamine" compartment="c" fbc:charge="0" fbc:chemicalFormula="C5H10N2O3"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_gln__L_e" name="L_Glutamine" compartment="e" fbc:charge="0" fbc:chemicalFormula="C5H10N2O3"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_glu5sa_c" name="L_Glutamate_5_semialdehyde" compartment="c" fbc:charge="0" fbc:chemicalFormula="C5H9NO3"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_glu__L_c" name="L_Glutamate" compartment="c" fbc:charge="0" fbc:chemicalFormula="C5H8NO4"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_glu__L_e" name="L_Glutamate" compartment="e" fbc:charge="0" fbc:chemicalFormula="C5H8NO4"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_glu__L_m" name="L_Glutamate" compartment="m" fbc:charge="0" fbc:chemicalFormula="C5H8NO4"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_glucys_c" name="gamma_L_Glutamyl_L_cysteine" compartment="c" fbc:charge="0" fbc:chemicalFormula="C8H13N2O5S"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_gluside_c" name="D-glucosyl-N-acylsphingosine" compartment="c" fbc:charge="[0]" fbc:chemicalFormula="[]"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_glutrna_c" name="L_Glutamyl_tRNA_Glu" compartment="c" fbc:charge="0" fbc:chemicalFormula="C5H7NO3R"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_gly_c" name="Glycine" compartment="c" fbc:charge="0" fbc:chemicalFormula="C2H5NO2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_gly_e" name="Glycine" compartment="e" fbc:charge="0" fbc:chemicalFormula="C2H5NO2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_gly_m" name="Glycine" compartment="m" fbc:charge="0" fbc:chemicalFormula="C2H5NO2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_glyald_c" name="D_Glyceraldehyde" compartment="c" fbc:charge="0" fbc:chemicalFormula="C3H6O3"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_glyc3p_ap" name="Glycerol_3_phosphate" compartment="ap" fbc:charge="0" fbc:chemicalFormula="C3H7O6P"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_glyc3p_c" name="Glycerol_3_phosphate" compartment="c" fbc:charge="0" fbc:chemicalFormula="C3H7O6P"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_glyc3p_m" name="Glycerol_3_phosphate" compartment="m" fbc:charge="0" fbc:chemicalFormula="C3H7O6P"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_glyc_c" name="Glycerol" compartment="c" fbc:charge="0" fbc:chemicalFormula="C3H8O3"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_glyc_e" name="Glycerol" compartment="e" fbc:charge="0" fbc:chemicalFormula="C3H8O3"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_gmp_c" name="GMP" compartment="c" fbc:charge="0" fbc:chemicalFormula="C10H12N5O8P"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_gpail_c" name="D-glucosaminylphosphatidylinositol" compartment="c" fbc:charge="[0]" fbc:chemicalFormula="['C15H28NO13PRCO2R2CO2']"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_grdp_c" name="Geranyl_diphosphate" compartment="c" fbc:charge="0" fbc:chemicalFormula="C10H17O7P2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_gsn_c" name="Guanosine" compartment="c" fbc:charge="0" fbc:chemicalFormula="C10H13N5O5"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_gsn_e" name="Guanosine" compartment="e" fbc:charge="0" fbc:chemicalFormula="C10H13N5O5"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_gthox_c" name="Oxidized_glutathione" compartment="c" fbc:charge="0" fbc:chemicalFormula="C20H30N6O12S2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_gthox_e" name="Oxidized_glutathione" compartment="e" fbc:charge="0" fbc:chemicalFormula="C20H30N6O12S2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_gthrd_c" name="Reduced_glutathione" compartment="c" fbc:charge="0" fbc:chemicalFormula="C10H16N3O6S"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_gthrd_e" name="Reduced_glutathione" compartment="e" fbc:charge="0" fbc:chemicalFormula="C10H16N3O6S"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_gtp_c" name="GTP" compartment="c" fbc:charge="0" fbc:chemicalFormula="C10H12N5O14P3"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_gtp_m" name="GTP" compartment="m" fbc:charge="0" fbc:chemicalFormula="C10H12N5O14P3"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_gua_c" name="Guanine" compartment="c" fbc:charge="0" fbc:chemicalFormula="C5H5N5O"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_gua_e" name="Guanine" compartment="e" fbc:charge="0" fbc:chemicalFormula="C5H5N5O"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_h2mb4p_ap" name="1_hydroxy_2_methyl_2_E_butenyl_4_diphosphate" compartment="ap" fbc:charge="0" fbc:chemicalFormula="C5H9O8P2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_h2o2_c" name="Hydrogen_peroxide" compartment="c" fbc:charge="0" fbc:chemicalFormula="H2O2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_h2o2_e" name="Hydrogen_peroxide" compartment="e" fbc:charge="0" fbc:chemicalFormula="H2O2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_h2o2_m" name="Hydrogen_peroxide" compartment="m" fbc:charge="0" fbc:chemicalFormula="H2O2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_h2o_ap" name="H2O" compartment="ap" fbc:charge="0" fbc:chemicalFormula="H2O"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_h2o_c" name="H2O" compartment="c" fbc:charge="0" fbc:chemicalFormula="H2O"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_h2o_e" name="H2O" compartment="e" fbc:charge="0" fbc:chemicalFormula="H2O"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_h2o_m" name="H2O" compartment="m" fbc:charge="0" fbc:chemicalFormula="H2O"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_h_ap" name="H" compartment="ap" fbc:charge="0" fbc:chemicalFormula="H"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_h_c" name="H" compartment="c" fbc:charge="0" fbc:chemicalFormula="H"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_h_e" name="H" compartment="e" fbc:charge="0" fbc:chemicalFormula="H"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_h_m" name="H" compartment="m" fbc:charge="0" fbc:chemicalFormula="H"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_hb_c" name="host hemoglobin" compartment="c" fbc:charge="[]" fbc:chemicalFormula="[]"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_hb_e" name="host hemoglobin" compartment="e" fbc:charge="[]" fbc:chemicalFormula="[]"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_hco3_ap" name="Bicarbonate" compartment="ap" fbc:charge="0" fbc:chemicalFormula="CHO3"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_hco3_c" name="Bicarbonate" compartment="c" fbc:charge="0" fbc:chemicalFormula="CHO3"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_hco3_e" name="Bicarbonate" compartment="e" fbc:charge="0" fbc:chemicalFormula="CHO3"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_hcys__L_c" name="L_Homocysteine" compartment="c" fbc:charge="0" fbc:chemicalFormula="C4H9NO2S"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_hcys__L_e" name="Homocysteine" compartment="e" fbc:charge="0"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_hdca_ap" name="Hexadecanoate_n_C160" compartment="ap" fbc:charge="0" fbc:chemicalFormula="C16H31O2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_hdca_c" name="Hexadecanoate_n_C160" compartment="c" fbc:charge="0" fbc:chemicalFormula="C16H31O2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_hdca_e" name="Hexadecanoate_n_C160" compartment="e" fbc:charge="0" fbc:chemicalFormula="C16H31O2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_hdcea_ap" name="Hexadecenoate_n_C161" compartment="ap" fbc:charge="0" fbc:chemicalFormula="C16H29O2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_hdcea_c" name="Hexadecenoate_n_C161" compartment="c" fbc:charge="0" fbc:chemicalFormula="C16H29O2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_hdcea_e" name="Hexadecenoate_n_C161" compartment="e" fbc:charge="0" fbc:chemicalFormula="C16H29O2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_hdcoa_ap" name="Hexadecenoyl_CoA_n_C161CoA" compartment="ap" fbc:charge="0" fbc:chemicalFormula="C37H60N7O17P3S"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_hdcoa_c" name="Hexadecenoyl_CoA_n_C161CoA" compartment="c" fbc:charge="0" fbc:chemicalFormula="C37H60N7O17P3S"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_hdcoa_e" name="Hexadecenoyl_CoA_n_C161CoA" compartment="e" fbc:charge="0" fbc:chemicalFormula="C37H60N7O17P3S"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_hdeACP_ap" name="cis_hexadec_9_enoyl_acyl_carrier_protein_n_C161" compartment="ap" fbc:charge="0" fbc:chemicalFormula="C27H49N2O8PRS"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_hepdp_m" name="all_trans_Heptaprenyl_diphosphate" compartment="m" fbc:charge="0" fbc:chemicalFormula="C35H57O7P2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_hexACP_ap" name="Hexanoyl_ACP_n_C60ACP" compartment="ap" fbc:charge="0" fbc:chemicalFormula="C17H31N2O8PRS"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_hexc_ap" name="hexacosanoate_n_C260" compartment="ap" fbc:charge="0" fbc:chemicalFormula="C26H51O2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_hexc_c" name="hexacosanoate_n_C260" compartment="c" fbc:charge="0" fbc:chemicalFormula="C26H51O2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_hexc_e" name="hexacosanoate_n_C260" compartment="e" fbc:charge="0" fbc:chemicalFormula="C26H51O2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_hexdp_m" name="all_trans_Hexaprenyl_diphosphate" compartment="m" fbc:charge="0" fbc:chemicalFormula="C30H49O7P2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_hibcoa_c" name="S_3_Hydroxyisobutyryl_CoA" compartment="c" fbc:charge="0" fbc:chemicalFormula="C25H38N7O18P3S"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_his__L_c" name="L_Histidine" compartment="c" fbc:charge="0" fbc:chemicalFormula="C6H9N3O2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_his__L_e" name="L_Histidine" compartment="e" fbc:charge="0" fbc:chemicalFormula="C6H9N3O2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_histrna_c" name="L_Histidyl_tRNA_His" compartment="c" fbc:charge="0" fbc:chemicalFormula="C6H8N3OR"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_hmbil_ap" name="Hydroxymethylbilane" compartment="ap" fbc:charge="0" fbc:chemicalFormula="C40H38N4O17"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_hmbil_c" name="Hydroxymethylbilane" compartment="c" fbc:charge="0" fbc:chemicalFormula="C40H38N4O17"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_hxa_ap" name="Hexanoate_n_C60" compartment="ap" fbc:charge="0" fbc:chemicalFormula="C6H11O2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_hxa_c" name="Hexanoate_n_C60" compartment="c" fbc:charge="0" fbc:chemicalFormula="C6H11O2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_hxa_e" name="Hexanoate_n_C60" compartment="e" fbc:charge="0" fbc:chemicalFormula="C6H11O2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_hxan_c" name="Hypoxanthine" compartment="c" fbc:charge="0" fbc:chemicalFormula="C5H4N4O"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_hxan_e" name="Hypoxanthine" compartment="e" fbc:charge="0" fbc:chemicalFormula="C5H4N4O"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_hxcoa_ap" name="Hexanoyl_CoA_n_C60CoA" compartment="ap" fbc:charge="0" fbc:chemicalFormula="C27H42N7O17P3S"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_hxcoa_c" name="Hexanoyl_CoA_n_C60CoA" compartment="c" fbc:charge="0" fbc:chemicalFormula="C27H42N7O17P3S"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_hxcoa_e" name="Hexanoyl_CoA_n_C60CoA" compartment="e" fbc:charge="0" fbc:chemicalFormula="C27H42N7O17P3S"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ibcoa_m" name="sobutyryl-CoA" compartment="m" fbc:charge="0" fbc:chemicalFormula="C25H38N7O17P3S"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_icit_c" name="Isocitrate" compartment="c" fbc:charge="0" fbc:chemicalFormula="C6H5O7"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_icit_m" name="Isocitrate" compartment="m" fbc:charge="0" fbc:chemicalFormula="C6H5O7"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ile__L_c" name="L_Isoleucine" compartment="c" fbc:charge="0" fbc:chemicalFormula="C6H13NO2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ile__L_e" name="L_Isoleucine" compartment="e" fbc:charge="0" fbc:chemicalFormula="C6H13NO2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_iletrna_c" name="L_Isoleucyl_tRNA_Ile" compartment="c" fbc:charge="0" fbc:chemicalFormula="C6H12NOR"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_imp_c" name="IMP" compartment="c" fbc:charge="0" fbc:chemicalFormula="C10H11N4O8P"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_inost_c" name="myo_Inositol" compartment="c" fbc:charge="0" fbc:chemicalFormula="C6H12O6"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_inost_e" name="myo_Inositol" compartment="e" fbc:charge="0" fbc:chemicalFormula="C6H12O6"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ins_c" name="Inosine" compartment="c" fbc:charge="0" fbc:chemicalFormula="C10H12N4O5"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ins_e" name="Inosine" compartment="e" fbc:charge="0" fbc:chemicalFormula="C10H12N4O5"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ipdp_ap" name="Isopentenyl_diphosphate" compartment="ap" fbc:charge="0" fbc:chemicalFormula="C5H9O7P2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ipdp_c" name="Isopentenyl_diphosphate" compartment="c" fbc:charge="0" fbc:chemicalFormula="C5H9O7P2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ipdp_m" name="Isopentenyl_diphosphate" compartment="m" fbc:charge="0" fbc:chemicalFormula="C5H9O7P2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_itp_c" name="ITP" compartment="c" fbc:charge="0" fbc:chemicalFormula="C10H11N4O14P3"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ivcoa_m" name="sovaleryl-CoA" compartment="m" fbc:charge="0" fbc:chemicalFormula="C26H40N7O17P3S"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_lac__D_c" name="D_Lactate" compartment="c" fbc:charge="0" fbc:chemicalFormula="C3H5O3"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_lac__D_e" name="D_Lactate" compartment="e" fbc:charge="0" fbc:chemicalFormula="C3H5O3"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_lac__L_c" name="L_Lactate" compartment="c" fbc:charge="0" fbc:chemicalFormula="C3H5O3"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_leu__L_c" name="L_Leucine" compartment="c" fbc:charge="0" fbc:chemicalFormula="C6H13NO2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_leu__L_e" name="L_Leucine" compartment="e" fbc:charge="0" fbc:chemicalFormula="C6H13NO2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_leutrna_c" name="L_Leucyl_tRNA_Leu" compartment="c" fbc:charge="0" fbc:chemicalFormula="C6H12NOR"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_lgt__S_c" name="R_S_Lactoylglutathione" compartment="c" fbc:charge="0" fbc:chemicalFormula="C13H20N3O8S"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_lpchol_c" name="Lysophosphatidylcholine" compartment="c" fbc:charge="[0]" fbc:chemicalFormula="['C8H19NO5PRCO2']"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_lys__L_c" name="L_Lysine" compartment="c" fbc:charge="0" fbc:chemicalFormula="C6H15N2O2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_lys__L_e" name="L_Lysine" compartment="e" fbc:charge="0" fbc:chemicalFormula="C6H15N2O2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_m5mpdol__L_c" name="alpha-D-Mannosyl)5-beta-D-mannosyl-diacetylchitobiosyldiphosphodolichol" compartment="c" fbc:charge="0"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_m6mpdol__L_c" name="alpha-D-Mannosyl)6-beta-D-mannosyl-diacetylchitobiosyldiphosphodolichol" compartment="c" fbc:charge="0"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_m7mpdol__L_c" name="alpha-D-Mannosyl)7-beta-D-mannosyl-diacetylchitobiosyldiphosphodolichol" compartment="c" fbc:charge="0"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_malACP_ap" name="Malonyl_acyl_carrier_protein" compartment="ap" fbc:charge="0" fbc:chemicalFormula="C14H22N2O10PRS"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_mal__L_c" name="L_Malate" compartment="c" fbc:charge="0" fbc:chemicalFormula="C4H4O5"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_mal__L_e" name="L_Malate" compartment="e" fbc:charge="0" fbc:chemicalFormula="C4H4O5"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_mal__L_m" name="L_Malate" compartment="m" fbc:charge="0" fbc:chemicalFormula="C4H4O5"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_malcoa_ap" name="Malonyl_CoA" compartment="ap" fbc:charge="0" fbc:chemicalFormula="C24H33N7O19P3S"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_malt_c" name="Maltose" compartment="c" fbc:charge="0" fbc:chemicalFormula="C12H22O11"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_malt_e" name="Maltose" compartment="e" fbc:charge="0" fbc:chemicalFormula="C12H22O11"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_man1p_c" name="D_Mannose_1_phosphate" compartment="c" fbc:charge="0" fbc:chemicalFormula="C6H11O9P"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_man6p_c" name="D_Mannose_6_phosphate" compartment="c" fbc:charge="0" fbc:chemicalFormula="C6H11O9P"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_man_c" name="D_Mannose" compartment="c" fbc:charge="0" fbc:chemicalFormula="C6H12O6"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_man_e" name="D_Mannose" compartment="e" fbc:charge="0" fbc:chemicalFormula="C6H12O6"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_met__L_c" name="L_Methionine" compartment="c" fbc:charge="0" fbc:chemicalFormula="C5H11NO2S"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_met__L_e" name="L_Methionine" compartment="e" fbc:charge="0" fbc:chemicalFormula="C5H11NO2S"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_methf_c" name="5_10_Methenyltetrahydrofolate" compartment="c" fbc:charge="0" fbc:chemicalFormula="C20H20N7O6"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_mettrna_c" name="L_Methionyl_tRNA_Met" compartment="c" fbc:charge="0" fbc:chemicalFormula="C5H10NOSR"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_mi13456p_c" name="1D-myo-Inositol 1,3,4,5,6-pentakisphosphate" compartment="c" fbc:charge="0" fbc:chemicalFormula="C6H7O21P5"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_mi1345p_c" name="1D-myo-Inositol 1,3,4,5-tetrakisphosphate" compartment="c" fbc:charge="0" fbc:chemicalFormula="C6H8O18P4"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_mi134p_c" name="1D-myo-Inositol 1,3,4-trisphosphate" compartment="c" fbc:charge="0" fbc:chemicalFormula="C6H9O15P3"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_mi1456p_c" name="1D-myo-Inositol 1,4,5,6-tetrakisphosphate" compartment="c" fbc:charge="0" fbc:chemicalFormula="C6H8O18P4"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_mi145p_c" name="1D_myo_Inositol_1_4_5_trisphosphate" compartment="c" fbc:charge="0" fbc:chemicalFormula="C6H9O15P3"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_mi14p_c" name="1D-myo-Inositol 1,4-bisphosphate" compartment="c" fbc:charge="0" fbc:chemicalFormula="C6H10O12P2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_mi1p__D_c" name="1D_myo_Inositol_1_phosphate" compartment="c" fbc:charge="0" fbc:chemicalFormula="C6H11O9P"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_mi34p_c" name="1D-myo-Inositol 3,4-bisphosphate" compartment="c" fbc:charge="0" fbc:chemicalFormula="C6H10O12P2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_mi4p__D_c" name="1D-myo-Inositol 4-phosphate" compartment="c" fbc:charge="0" fbc:chemicalFormula="C6H11O9P"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_mlthf_c" name="5_10_Methylenetetrahydrofolate" compartment="c" fbc:charge="0" fbc:chemicalFormula="C20H21N7O6"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_mlthf_m" name="5_10_Methylenetetrahydrofolate" compartment="m" fbc:charge="0" fbc:chemicalFormula="C20H21N7O6"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_mql8_c" name="Menaquinol_8" compartment="c" fbc:charge="0" fbc:chemicalFormula="C51H74O2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_mthgxl_c" name="Methylglyoxal" compartment="c" fbc:charge="0" fbc:chemicalFormula="C3H4O2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_mthgxl_e" name="Methylglyoxal" compartment="e" fbc:charge="0" fbc:chemicalFormula="C3H4O2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_myrsACP_ap" name="Myristoyl_ACP_n_C140ACP" compartment="ap" fbc:charge="0" fbc:chemicalFormula="C25H47N2O8PRS"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_nac_c" name="Nicotinate" compartment="c" fbc:charge="0" fbc:chemicalFormula="C6H4NO2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_nac_e" name="Nicotinate" compartment="e" fbc:charge="0" fbc:chemicalFormula="C6H4NO2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_nad_ap" name="Nicotinamide_adenine_dinucleotide" compartment="ap" fbc:charge="0" fbc:chemicalFormula="C21H26N7O14P2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_nad_c" name="Nicotinamide_adenine_dinucleotide" compartment="c" fbc:charge="0" fbc:chemicalFormula="C21H26N7O14P2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_nad_m" name="Nicotinamide_adenine_dinucleotide" compartment="m" fbc:charge="0" fbc:chemicalFormula="C21H26N7O14P2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_nadh_ap" name="Nicotinamide_adenine_dinucleotide_reduced" compartment="ap" fbc:charge="0" fbc:chemicalFormula="C21H27N7O14P2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_nadh_c" name="Nicotinamide_adenine_dinucleotide_reduced" compartment="c" fbc:charge="0" fbc:chemicalFormula="C21H27N7O14P2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_nadh_m" name="Nicotinamide_adenine_dinucleotide_reduced" compartment="m" fbc:charge="0" fbc:chemicalFormula="C21H27N7O14P2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_nadp_ap" name="Nicotinamide_adenine_dinucleotide_phosphate" compartment="ap" fbc:charge="0" fbc:chemicalFormula="C21H25N7O17P3"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_nadp_c" name="Nicotinamide_adenine_dinucleotide_phosphate" compartment="c" fbc:charge="0" fbc:chemicalFormula="C21H25N7O17P3"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_nadp_m" name="Nicotinamide_adenine_dinucleotide_phosphate" compartment="m" fbc:charge="0" fbc:chemicalFormula="C21H25N7O17P3"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_nadph_ap" name="Nicotinamide_adenine_dinucleotide_phosphate_reduced" compartment="ap" fbc:charge="0" fbc:chemicalFormula="C21H26N7O17P3"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_nadph_c" name="Nicotinamide_adenine_dinucleotide_phosphate_reduced" compartment="c" fbc:charge="0" fbc:chemicalFormula="C21H26N7O17P3"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_nadph_m" name="Nicotinamide_adenine_dinucleotide_phosphate_reduced" compartment="m" fbc:charge="0" fbc:chemicalFormula="C21H26N7O17P3"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ncam_c" name="Nicotinamide" compartment="c" fbc:charge="0" fbc:chemicalFormula="C6H6N2O"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ncam_e" name="Nicotinamide" compartment="e" fbc:charge="0" fbc:chemicalFormula="C6H6N2O"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_nh4_ap" name="Ammonium" compartment="ap" fbc:charge="0" fbc:chemicalFormula="H4N"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_nh4_c" name="Ammonium" compartment="c" fbc:charge="0" fbc:chemicalFormula="H4N"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_nh4_e" name="Ammonium" compartment="e" fbc:charge="0" fbc:chemicalFormula="H4N"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_nh4_m" name="Ammonium" compartment="m" fbc:charge="0" fbc:chemicalFormula="H4N"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_nicrnt_c" name="Nicotinate_D_ribonucleotide" compartment="c" fbc:charge="0" fbc:chemicalFormula="C11H12NO9P"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_no2_c" name="Nitrite" compartment="c" fbc:charge="0" fbc:chemicalFormula="NO2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_no2_e" name="Nitrite" compartment="e" fbc:charge="0" fbc:chemicalFormula="NO2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_no2_m" name="Nitrite" compartment="m" fbc:charge="0" fbc:chemicalFormula="NO2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_no3_c" name="Nitrate" compartment="c" fbc:charge="0" fbc:chemicalFormula="NO3"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_no3_e" name="Nitrate" compartment="e" fbc:charge="0" fbc:chemicalFormula="NO3"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_no3_m" name="Nitrate" compartment="m" fbc:charge="0" fbc:chemicalFormula="NO3"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_no_e" name="Nitric_oxide" compartment="e" fbc:charge="0" fbc:chemicalFormula="NO"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_o2_ap" name="O2" compartment="ap" fbc:charge="0" fbc:chemicalFormula="O2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_o2_c" name="O2" compartment="c" fbc:charge="0" fbc:chemicalFormula="O2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_o2_e" name="O2" compartment="e" fbc:charge="0" fbc:chemicalFormula="O2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_o2_m" name="O2" compartment="m" fbc:charge="0" fbc:chemicalFormula="O2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_o2s_e" name="Superoxide_anion" compartment="e" fbc:charge="0" fbc:chemicalFormula="O2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_oaa_c" name="Oxaloacetate" compartment="c" fbc:charge="0" fbc:chemicalFormula="C4H2O5"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_oaa_m" name="Oxaloacetate" compartment="m" fbc:charge="0" fbc:chemicalFormula="C4H2O5"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ocACP_ap" name="Octanoyl_ACP_n_C80ACP" compartment="ap" fbc:charge="0" fbc:chemicalFormula="C19H35N2O8PRS"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_occoa_ap" name="Octanoyl_CoA_n_C80CoA" compartment="ap" fbc:charge="0" fbc:chemicalFormula="C29H46N7O17P3S"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_occoa_c" name="Octanoyl_CoA_n_C80CoA" compartment="c" fbc:charge="0" fbc:chemicalFormula="C29H46N7O17P3S"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_occoa_e" name="Octanoyl_CoA_n_C80CoA" compartment="e" fbc:charge="0" fbc:chemicalFormula="C29H46N7O17P3S"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ocdcaACP_ap" name="Octadecanoyl_ACP_n_C180ACP" compartment="ap" fbc:charge="0" fbc:chemicalFormula="C29H55N2O8PRS"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ocdca_ap" name="octadecanoate_n_C180" compartment="ap" fbc:charge="0" fbc:chemicalFormula="C18H35O2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ocdca_c" name="octadecanoate_n_C180" compartment="c" fbc:charge="0" fbc:chemicalFormula="C18H35O2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ocdca_e" name="octadecanoate_n_C180" compartment="e" fbc:charge="0" fbc:chemicalFormula="C18H35O2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ocdcea_ap" name="octadecenoate_n_C181" compartment="ap" fbc:charge="0" fbc:chemicalFormula="C18H33O2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ocdcea_c" name="octadecenoate_n_C181" compartment="c" fbc:charge="0" fbc:chemicalFormula="C18H33O2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ocdcea_e" name="octadecenoate_n_C181" compartment="e" fbc:charge="0" fbc:chemicalFormula="C18H33O2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ocdycacoa_c" name="Octadecynoyl_CoA_n_C182CoA" compartment="c" fbc:charge="0" fbc:chemicalFormula="C39H62N7O17P3S"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_octa_ap" name="octanoate_n_C80" compartment="ap" fbc:charge="0" fbc:chemicalFormula="C8H15O2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_octa_c" name="octanoate_n_C80" compartment="c" fbc:charge="0" fbc:chemicalFormula="C8H15O2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_octa_e" name="octanoate_n_C80" compartment="e" fbc:charge="0" fbc:chemicalFormula="C8H15O2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_octdp_c" name="all_trans_Octaprenyl_diphosphate" compartment="c" fbc:charge="0" fbc:chemicalFormula="C40H65O7P2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_octdp_m" name="all_trans_Octaprenyl_diphosphate" compartment="m" fbc:charge="0" fbc:chemicalFormula="C40H65O7P2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_octeACP_ap" name="cis_octadec_11_enoyl_acyl_carrier_protein_n_C181" compartment="ap" fbc:charge="0" fbc:chemicalFormula="C29H53N2O8PRS"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_odecoa_ap" name="Octadecenoyl_CoA_n_C181CoA" compartment="ap" fbc:charge="0" fbc:chemicalFormula="C39H64N7O17P3S"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_odecoa_c" name="Octadecenoyl_CoA_n_C181CoA" compartment="c" fbc:charge="0" fbc:chemicalFormula="C39H64N7O17P3S"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_odecoa_e" name="Octadecenoyl_CoA_n_C181CoA" compartment="e" fbc:charge="0" fbc:chemicalFormula="C39H64N7O17P3S"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_oh1_c" name="hydroxide_ion" compartment="c" fbc:charge="0" fbc:chemicalFormula="HO"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_oh1_m" name="hydroxide_ion" compartment="m" fbc:charge="0" fbc:chemicalFormula="HO"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_orn_c" name="Ornithine" compartment="c" fbc:charge="0" fbc:chemicalFormula="C5H13N2O2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_orn_e" name="Ornithine" compartment="e" fbc:charge="0" fbc:chemicalFormula="C5H13N2O2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_orot5p_c" name="Orotidine_5_phosphate" compartment="c" fbc:charge="0" fbc:chemicalFormula="C10H10N2O11P"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_orot_c" name="Orotate" compartment="c" fbc:charge="0" fbc:chemicalFormula="C5H3N2O4"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_orot_m" name="Orotate" compartment="m" fbc:charge="0" fbc:chemicalFormula="C5H3N2O4"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_oxa_c" name="xalate" compartment="c" fbc:charge="0" fbc:chemicalFormula="C2O4"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_oxa_e" name="xalate" compartment="e" fbc:charge="0" fbc:chemicalFormula="C2O4"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pa120_ap" name="1_2_didodecanoyl_sn_glycerol_3_phosphate" compartment="ap" fbc:charge="0" fbc:chemicalFormula="C27H51O8P1"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pa120_c" name="1_2_didodecanoyl_sn_glycerol_3_phosphate" compartment="c" fbc:charge="0" fbc:chemicalFormula="C27H51O8P1"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pa140_ap" name="1_2_ditetradecanoyl_sn_glycerol_3_phosphate" compartment="ap" fbc:charge="0" fbc:chemicalFormula="C31H59O8P1"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pa140_c" name="1_2_ditetradecanoyl_sn_glycerol_3_phosphate" compartment="c" fbc:charge="0" fbc:chemicalFormula="C31H59O8P1"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pa141_ap" name="1_2_ditetradec_7_enoyl_sn_glycerol_3_phosphate" compartment="ap" fbc:charge="0" fbc:chemicalFormula="C31H55O8P1"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pa141_c" name="1_2_ditetradec_7_enoyl_sn_glycerol_3_phosphate" compartment="c" fbc:charge="0" fbc:chemicalFormula="C31H55O8P1"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pa160_ap" name="1_2_dihexadecanoyl_sn_glycerol_3_phosphate" compartment="ap" fbc:charge="0" fbc:chemicalFormula="C35H67O8P1"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pa160_c" name="1_2_dihexadecanoyl_sn_glycerol_3_phosphate" compartment="c" fbc:charge="0" fbc:chemicalFormula="C35H67O8P1"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pa161_ap" name="1_2_dihexadec_9_enoyl_sn_glycerol_3_phosphate" compartment="ap" fbc:charge="0" fbc:chemicalFormula="C35H63O8P1"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pa161_c" name="1_2_dihexadec_9_enoyl_sn_glycerol_3_phosphate" compartment="c" fbc:charge="0" fbc:chemicalFormula="C35H63O8P1"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pa180_ap" name="1_2_dioctadecanoyl_sn_glycerol_3_phosphate" compartment="ap" fbc:charge="0" fbc:chemicalFormula="C39H75O8P1"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pa180_c" name="1_2_dioctadecanoyl_sn_glycerol_3_phosphate" compartment="c" fbc:charge="0" fbc:chemicalFormula="C39H75O8P1"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pa181_ap" name="1_2_dioctadec_11_enoyl_sn_glycerol_3_phosphate" compartment="ap" fbc:charge="0" fbc:chemicalFormula="C39H71O8P1"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pa181_c" name="1_2_dioctadec_11_enoyl_sn_glycerol_3_phosphate" compartment="c" fbc:charge="0" fbc:chemicalFormula="C39H71O8P1"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pail_c" name="phosphatidylinositol" compartment="c" fbc:charge="[-1]" fbc:chemicalFormula="['C9H16O9PRCO2R2CO2']"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_palmACP_ap" name="Palmitoyl_ACP_n_C160ACP" compartment="ap" fbc:charge="0" fbc:chemicalFormula="C27H51N2O8PRS"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pan4p_c" name="Pantetheine_4_phosphate" compartment="c" fbc:charge="0" fbc:chemicalFormula="C11H21N2O7PS"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pap_c" name="Adenosine_3_5_bisphosphate" compartment="c" fbc:charge="0" fbc:chemicalFormula="C10H11N5O10P2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pap_e" name="Adenosine_3_5_bisphosphate" compartment="e" fbc:charge="0" fbc:chemicalFormula="C10H11N5O10P2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pc_c" name="Phosphatidylcholine" compartment="c" fbc:charge="[]" fbc:chemicalFormula="[]"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pc_e" name="Phosphatidylcholine" compartment="e" fbc:charge="[]" fbc:chemicalFormula="[]"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pdx5p_c" name="Pyridoxine_5_phosphate" compartment="c" fbc:charge="0" fbc:chemicalFormula="C8H10NO6P"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pe120_c" name="phosphatidylethanolamine_didodecanoyl_n_C120" compartment="c" fbc:charge="0" fbc:chemicalFormula="C29H58N1O8P1"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pe120_e" name="phosphatidylethanolamine_didodecanoyl_n_C120" compartment="e" fbc:charge="0" fbc:chemicalFormula="C29H58N1O8P1"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pe140_c" name="phosphatidylethanolamine_ditetradecanoyl_n_C140" compartment="c" fbc:charge="0" fbc:chemicalFormula="C33H66N1O8P1"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pe140_e" name="phosphatidylethanolamine_ditetradecanoyl_n_C140" compartment="e" fbc:charge="0" fbc:chemicalFormula="C33H66N1O8P1"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pe141_c" name="phosphatidylethanolamine_ditetradec_7_enoyl_n_C141" compartment="c" fbc:charge="0" fbc:chemicalFormula="C33H62N1O8P1"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pe141_e" name="phosphatidylethanolamine_ditetradec_7_enoyl_n_C141" compartment="e" fbc:charge="0" fbc:chemicalFormula="C33H62N1O8P1"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pe160_c" name="phosphatidylethanolamine_dihexadecanoyl_n_C160" compartment="c" fbc:charge="0" fbc:chemicalFormula="C37H74N1O8P1"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pe160_e" name="phosphatidylethanolamine_dihexadecanoyl_n_C160" compartment="e" fbc:charge="0" fbc:chemicalFormula="C37H74N1O8P1"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pe161_c" name="phosphatidylethanolamine_dihexadec_9enoyl_n_C161" compartment="c" fbc:charge="0" fbc:chemicalFormula="C37H70N1O8P1"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pe161_e" name="phosphatidylethanolamine_dihexadec_9enoyl_n_C161" compartment="e" fbc:charge="0" fbc:chemicalFormula="C37H70N1O8P1"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pe180_c" name="phosphatidylethanolamine_dioctadecanoyl_n_C180" compartment="c" fbc:charge="0" fbc:chemicalFormula="C41H82N1O8P1"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pe180_e" name="phosphatidylethanolamine_dioctadecanoyl_n_C180" compartment="e" fbc:charge="0" fbc:chemicalFormula="C41H82N1O8P1"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pe181_c" name="phosphatidylethanolamine_dioctadec_11_enoyl_n_C181" compartment="c" fbc:charge="0" fbc:chemicalFormula="C41H78N1O8P1"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pe181_e" name="phosphatidylethanolamine_dioctadec_11_enoyl_n_C181" compartment="e" fbc:charge="0" fbc:chemicalFormula="C41H78N1O8P1"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pe_c" name="Phosphatidylethanolamine" compartment="c" fbc:charge="[]" fbc:chemicalFormula="[]"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pe_e" name="Phosphatidylethanolamine" compartment="e" fbc:charge="[]" fbc:chemicalFormula="[]"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pendp_c" name="all_trans_Pentaprenyl_diphosphate" compartment="c" fbc:charge="0" fbc:chemicalFormula="C25H41O7P2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pendp_m" name="all_trans_Pentaprenyl_diphosphate" compartment="m" fbc:charge="0" fbc:chemicalFormula="C25H41O7P2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pep_ap" name="Phosphoenolpyruvate" compartment="ap" fbc:charge="0" fbc:chemicalFormula="C3H2O6P"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pep_c" name="Phosphoenolpyruvate" compartment="c" fbc:charge="0" fbc:chemicalFormula="C3H2O6P"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pg120_c" name="Phosphatidylglycerol_didodecanoyl_n_C120" compartment="c" fbc:charge="0" fbc:chemicalFormula="C30H58O10P1"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pg140_c" name="Phosphatidylglycerol_ditetradecanoyl_n_C140" compartment="c" fbc:charge="0" fbc:chemicalFormula="C34H66O10P1"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pg141_c" name="Phosphatidylglycerol_ditetradec_7_enoyl_n_C141" compartment="c" fbc:charge="0" fbc:chemicalFormula="C34H62O10P1"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pg160_c" name="Phosphatidylglycerol_dihexadecanoyl_n_C160" compartment="c" fbc:charge="0" fbc:chemicalFormula="C38H74O10P1"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pg161_c" name="Phosphatidylglycerol_dihexadec_9_enoyl_n_C161" compartment="c" fbc:charge="0" fbc:chemicalFormula="C38H70O10P1"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pg180_c" name="Phosphatidylglycerol_dioctadecanoyl_n_C180" compartment="c" fbc:charge="0" fbc:chemicalFormula="C42H82O10P1"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pg181_c" name="Phosphatidylglycerol_dioctadec_11_enoyl_n_C181" compartment="c" fbc:charge="0" fbc:chemicalFormula="C42H78O10P1"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pgp120_c" name="Phosphatidylglycerophosphate_didodecanoyl_n_C120" compartment="c" fbc:charge="0" fbc:chemicalFormula="C30H57O13P2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pgp140_c" name="Phosphatidylglycerophosphate_ditetradecanoyl_n_C140" compartment="c" fbc:charge="0" fbc:chemicalFormula="C34H65O13P2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pgp141_c" name="Phosphatidylglycerophosphate_ditetradec_7_enoyl_n_C141" compartment="c" fbc:charge="0" fbc:chemicalFormula="C34H61O13P2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pgp160_c" name="Phosphatidylglycerophosphate_dihexadecanoyl_n_C160" compartment="c" fbc:charge="0" fbc:chemicalFormula="C38H73O13P2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pgp161_c" name="Phosphatidylglycerophosphate_dihexadec_9_enoyl_n_C161" compartment="c" fbc:charge="0" fbc:chemicalFormula="C38H69O13P2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pgp180_c" name="Phosphatidylglycerophosphate_dioctadecanoyl_n_C180" compartment="c" fbc:charge="0" fbc:chemicalFormula="C42H81O13P2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pgp181_c" name="Phosphatidylglycerophosphate_dioctadec_11_enoyl_n_C181" compartment="c" fbc:charge="0" fbc:chemicalFormula="C42H77O13P2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_phe__L_c" name="L_Phenylalanine" compartment="c" fbc:charge="0" fbc:chemicalFormula="C9H11NO2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_phe__L_e" name="L_Phenylalanine" compartment="e" fbc:charge="0" fbc:chemicalFormula="C9H11NO2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pheme_ap" name="Protoheme" compartment="ap" fbc:charge="0" fbc:chemicalFormula="C34H30FeN4O4"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pheme_c" name="Protoheme" compartment="c" fbc:charge="0" fbc:chemicalFormula="C34H30FeN4O4"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pheme_m" name="Protoheme" compartment="m" fbc:charge="0" fbc:chemicalFormula="C34H30FeN4O4"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_phpyr_c" name="Phenylpyruvate" compartment="c" fbc:charge="0" fbc:chemicalFormula="C9H7O3"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pi_ap" name="Phosphate" compartment="ap" fbc:charge="0" fbc:chemicalFormula="HO4P"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pi_c" name="Phosphate" compartment="c" fbc:charge="0" fbc:chemicalFormula="HO4P"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pi_e" name="Phosphate" compartment="e" fbc:charge="0" fbc:chemicalFormula="HO4P"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pi_m" name="Phosphate" compartment="m" fbc:charge="0" fbc:chemicalFormula="HO4P"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pmtcoa_ap" name="Palmitoyl_CoA_n_C160CoA" compartment="ap" fbc:charge="0" fbc:chemicalFormula="C37H62N7O17P3S"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pmtcoa_c" name="Palmitoyl_CoA_n_C160CoA" compartment="c" fbc:charge="0" fbc:chemicalFormula="C37H62N7O17P3S"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pmtcoa_e" name="Palmitoyl_CoA_n_C160CoA" compartment="e" fbc:charge="0" fbc:chemicalFormula="C37H62N7O17P3S"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pnto__R_c" name="R_Pantothenate" compartment="c" fbc:charge="0" fbc:chemicalFormula="C9H16NO5"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pnto__R_e" name="R_Pantothenate" compartment="e" fbc:charge="0" fbc:chemicalFormula="C9H16NO5"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ppa_c" name="Propionate_n_C30" compartment="c" fbc:charge="0" fbc:chemicalFormula="C3H5O2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ppa_e" name="Propionate_n_C30" compartment="e" fbc:charge="0" fbc:chemicalFormula="C3H5O2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ppbng_ap" name="Porphobilinogen" compartment="ap" fbc:charge="0" fbc:chemicalFormula="C10H13N2O4"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ppcoa_c" name="Propanoyl_CoA" compartment="c" fbc:charge="0" fbc:chemicalFormula="C24H36N7O17P3S"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ppi_ap" name="Diphosphate" compartment="ap" fbc:charge="0" fbc:chemicalFormula="HO7P2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ppi_c" name="Diphosphate" compartment="c" fbc:charge="0" fbc:chemicalFormula="HO7P2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ppi_m" name="Diphosphate" compartment="m" fbc:charge="0" fbc:chemicalFormula="HO7P2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ppp9_ap" name="Protoporphyrin" compartment="ap" fbc:charge="0" fbc:chemicalFormula="C34H32N4O4"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ppp9_c" name="Protoporphyrin" compartment="c" fbc:charge="0" fbc:chemicalFormula="C34H32N4O4"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ppp9_m" name="Protoporphyrin" compartment="m" fbc:charge="0" fbc:chemicalFormula="C34H32N4O4"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pppg9_ap" name="Protoporphyrinogen_IX" compartment="ap" fbc:charge="0" fbc:chemicalFormula="C34H38N4O4"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pppg9_c" name="Protoporphyrinogen_IX" compartment="c" fbc:charge="0" fbc:chemicalFormula="C34H38N4O4"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pppg9_m" name="Protoporphyrinogen_IX" compartment="m" fbc:charge="0" fbc:chemicalFormula="C34H38N4O4"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pppi_c" name="Inorganic_triphosphate" compartment="c" fbc:charge="0" fbc:chemicalFormula="HO10P3"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pro__L_c" name="L_Proline" compartment="c" fbc:charge="0" fbc:chemicalFormula="C5H9NO2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pro__L_e" name="L_Proline" compartment="e" fbc:charge="0" fbc:chemicalFormula="C5H9NO2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_progly_c" name="L_Prolinylglycine" compartment="c" fbc:charge="0" fbc:chemicalFormula="C7H12N2O3"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_prpp_c" name="5_Phospho_alpha_D_ribose_1_diphosphate" compartment="c" fbc:charge="0" fbc:chemicalFormula="C5H8O14P3"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ps120_c" name="phosphatidylserine_didodecanoyl_n_C120" compartment="c" fbc:charge="0" fbc:chemicalFormula="C30H57N1O10P1"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ps140_c" name="phosphatidylserine_ditetradecanoyl_n_C140" compartment="c" fbc:charge="0" fbc:chemicalFormula="C34H65N1O10P1"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ps141_c" name="phosphatidylserine_ditetradec_7_enoyl_n_C141" compartment="c" fbc:charge="0" fbc:chemicalFormula="C34H61N1O10P1"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ps160_c" name="phosphatidylserine_dihexadecanoyl_n_C160" compartment="c" fbc:charge="0" fbc:chemicalFormula="C38H73N1O10P1"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ps161_c" name="phosphatidylserine_dihexadec_9_enoyl_n_C161" compartment="c" fbc:charge="0" fbc:chemicalFormula="C38H69N1O10P1"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ps180_c" name="phosphatidylserine_dioctadecanoyl_n_C180" compartment="c" fbc:charge="0" fbc:chemicalFormula="C42H81N1O10P1"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ps181_c" name="phosphatidylserine_dioctadec_11_enoyl_n_C181" compartment="c" fbc:charge="0" fbc:chemicalFormula="C42H77N1O10P1"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_psd5p_c" name="Pseudouridine_5_phosphate" compartment="c" fbc:charge="0" fbc:chemicalFormula="C9H11N2O9P"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ptd145bp_c" name="1 Phosphatidyl D myo inositol 4 5 bisphosphate " compartment="c" fbc:charge="[]" fbc:chemicalFormula="[]"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ptd1ino_c" name="Phosphatidyl 1D myo inositol" compartment="c" fbc:charge="[]" fbc:chemicalFormula="[]"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ptd1ino_e" name="Phosphatidyl 1D myo inositol" compartment="e" fbc:charge="[]" fbc:chemicalFormula="[]"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ptd3ino_c" name="Phosphatidyl 3D myo inositol" compartment="c" fbc:charge="[]" fbc:chemicalFormula="[]"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ptd4ino_c" name="Phosphatidyl 4D myo inositol" compartment="c" fbc:charge="[]" fbc:chemicalFormula="[]"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ptrc_c" name="Putrescine" compartment="c" fbc:charge="0" fbc:chemicalFormula="C4H14N2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ptrc_e" name="Putrescine" compartment="e" fbc:charge="0" fbc:chemicalFormula="C4H14N2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pyam5p_c" name="Pyridoxamine_5_phosphate" compartment="c" fbc:charge="0" fbc:chemicalFormula="C8H12N2O5P"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pydam_c" name="Pyridoxamine" compartment="c" fbc:charge="0" fbc:chemicalFormula="C8H13N2O2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pydam_e" name="Pyridoxamine" compartment="e" fbc:charge="0" fbc:chemicalFormula="C8H13N2O2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pydx5p_c" name="Pyridoxal_5_phosphate" compartment="c" fbc:charge="0" fbc:chemicalFormula="C8H8NO6P"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pydx_c" name="Pyridoxal" compartment="c" fbc:charge="0" fbc:chemicalFormula="C8H9NO3"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pydx_e" name="Pyridoxal" compartment="e" fbc:charge="0" fbc:chemicalFormula="C8H9NO3"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pydxn_c" name="Pyridoxine" compartment="c" fbc:charge="0" fbc:chemicalFormula="C8H11NO3"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pydxn_e" name="Pyridoxine" compartment="e" fbc:charge="0" fbc:chemicalFormula="C8H11NO3"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pyr_ap" name="Pyruvate" compartment="ap" fbc:charge="0" fbc:chemicalFormula="C3H3O3"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pyr_c" name="Pyruvate" compartment="c" fbc:charge="0" fbc:chemicalFormula="C3H3O3"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pyr_e" name="Pyruvate" compartment="e" fbc:charge="0" fbc:chemicalFormula="C3H3O3"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_q8_c" name="Ubiquinone_8" compartment="c" fbc:charge="0" fbc:chemicalFormula="C49H74O4"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_q8_m" name="Ubiquinone_8" compartment="m" fbc:charge="0" fbc:chemicalFormula="C49H74O4"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_q8h2_c" name="Ubiquinol_8" compartment="c" fbc:charge="0" fbc:chemicalFormula="C49H76O4"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_q8h2_m" name="Ubiquinol_8" compartment="m" fbc:charge="0" fbc:chemicalFormula="C49H76O4"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_r15bp_c" name="D_Ribose_1_5_bisphosphate" compartment="c" fbc:charge="0" fbc:chemicalFormula="C5H8O11P2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_r1p_c" name="alpha_D_Ribose_1_phosphate" compartment="c" fbc:charge="0" fbc:chemicalFormula="C5H9O8P"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_r5p_c" name="alpha_D_Ribose_5_phosphate" compartment="c" fbc:charge="0" fbc:chemicalFormula="C5H9O8P"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ribflv_c" name="Riboflavin" compartment="c" fbc:charge="0" fbc:chemicalFormula="C17H20N4O6"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ribflv_e" name="Riboflavin" compartment="e" fbc:charge="0" fbc:chemicalFormula="C17H20N4O6"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ru5p__D_c" name="D_Ribulose_5_phosphate" compartment="c" fbc:charge="0" fbc:chemicalFormula="C5H9O8P"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_saccrp__L_c" name="L_Saccharopine" compartment="c" fbc:charge="0" fbc:chemicalFormula="C11H19N2O6"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_sbt__D_c" name="D_Sorbitol" compartment="c" fbc:charge="0" fbc:chemicalFormula="C6H14O6"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_sbt__D_e" name="D_Sorbitol" compartment="e" fbc:charge="0" fbc:chemicalFormula="C6H14O6"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_seln_c" name="Selenide" compartment="c" fbc:charge="0" fbc:chemicalFormula="HSe"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_selnp_c" name="Selenophosphate" compartment="c" fbc:charge="0" fbc:chemicalFormula="H2O3PSe"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ser__L_c" name="L_Serine" compartment="c" fbc:charge="0" fbc:chemicalFormula="C3H7NO3"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ser__L_e" name="L_Serine" compartment="e" fbc:charge="0" fbc:chemicalFormula="C3H7NO3"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_sertrna_c" name="L_Seryl_tRNA_Ser" compartment="c" fbc:charge="0" fbc:chemicalFormula="C3H6NO2R"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_sertrna_sec_c" name="L_Seryl_tRNA_Sec" compartment="c" fbc:charge="0" fbc:chemicalFormula="C3H6NO2R"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_skm5p_c" name="Shikimate_5_phosphate" compartment="c" fbc:charge="0" fbc:chemicalFormula="C7H8O8P"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_skm_c" name="Shikimate" compartment="c" fbc:charge="0" fbc:chemicalFormula="C7H9O5"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_so4_c" name="Sulfate" compartment="c" fbc:charge="0" fbc:chemicalFormula="O4S"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_so4_e" name="Sulfate" compartment="e" fbc:charge="0" fbc:chemicalFormula="O4S"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_sphgn_c" name="Sphinganine" compartment="c" fbc:charge="0" fbc:chemicalFormula="C18H40NO2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_sphmyln_c" name="Sphingomyelin (generic)" compartment="c" fbc:charge="[0]" fbc:chemicalFormula="['C23H48N2O5PRCO']"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_spmd_c" name="Spermidine" compartment="c" fbc:charge="0" fbc:chemicalFormula="C7H22N3"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_spmd_e" name="Spermidine" compartment="e" fbc:charge="0" fbc:chemicalFormula="C7H22N3"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_stcoa_ap" name="Stearoyl_CoA_n_C180CoA" compartment="ap" fbc:charge="0" fbc:chemicalFormula="C39H66N7O17P3S"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_stcoa_c" name="Stearoyl_CoA_n_C180CoA" compartment="c" fbc:charge="0" fbc:chemicalFormula="C39H66N7O17P3S"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_stcoa_e" name="Stearoyl_CoA_n_C180CoA" compartment="e" fbc:charge="0" fbc:chemicalFormula="C39H66N7O17P3S"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_succ_c" name="Succinate" compartment="c" fbc:charge="0" fbc:chemicalFormula="C4H4O4"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_succ_e" name="Succinate" compartment="e" fbc:charge="0" fbc:chemicalFormula="C4H4O4"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_succ_m" name="Succinate" compartment="m" fbc:charge="0" fbc:chemicalFormula="C4H4O4"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_succoa_m" name="Succinyl_CoA" compartment="m" fbc:charge="0" fbc:chemicalFormula="C25H35N7O19P3S"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_t3c11vaceACP_ap" name="trans_3_cis_11_vacceoyl_acyl_carrier_protein" compartment="ap" fbc:charge="0" fbc:chemicalFormula="C29H51N2O8PRS"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_t3c5ddeceACP_ap" name="trans_3_cis_5_dodecenoyl_acyl_carrier_protein" compartment="ap" fbc:charge="0" fbc:chemicalFormula="C23H39N2O8PRS"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_t3c7mrseACP_ap" name="trans_3_cis_7_myristoleoyl_acyl_carrier_protein" compartment="ap" fbc:charge="0" fbc:chemicalFormula="C25H43N2O8PRS"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_t3c9palmeACP_ap" name="trans_3_cis_9_palmitoleoyl_acyl_carrier_protein" compartment="ap" fbc:charge="0" fbc:chemicalFormula="C27H47N2O8PRS"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_tag_c" name="triacylglycerols (total)" compartment="c" fbc:charge="[]" fbc:chemicalFormula="[]"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_tdcoa_ap" name="Tetradecanoyl_CoA_n_C140CoA" compartment="ap" fbc:charge="0" fbc:chemicalFormula="C35H58N7O17P3S"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_tdcoa_c" name="Tetradecanoyl_CoA_n_C140CoA" compartment="c" fbc:charge="0" fbc:chemicalFormula="C35H58N7O17P3S"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_tdcoa_e" name="Tetradecanoyl_CoA_n_C140CoA" compartment="e" fbc:charge="0" fbc:chemicalFormula="C35H58N7O17P3S"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_tddec2eACP_ap" name="trans_Dodec_2_enoyl_acyl_carrier_protein" compartment="ap" fbc:charge="0" fbc:chemicalFormula="C23H41N2O8PRS"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_tdeACP_ap" name="cis_tetradec_7_enoyl_acyl_carrier_protein_n_C141" compartment="ap" fbc:charge="0" fbc:chemicalFormula="C25H45N2O8PRS"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_tdec2eACP_ap" name="trans_Dec_2_enoyl_acyl_carrier_protein" compartment="ap" fbc:charge="0" fbc:chemicalFormula="C21H37N2O8PRS"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_tdecoa_ap" name="Tetradecenoyl_CoA_n_C141CoA" compartment="ap" fbc:charge="0" fbc:chemicalFormula="C35H56N7O17P3S"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_tdecoa_c" name="Tetradecenoyl_CoA_n_C141CoA" compartment="c" fbc:charge="0" fbc:chemicalFormula="C35H56N7O17P3S"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_tdecoa_e" name="Tetradecenoyl_CoA_n_C141CoA" compartment="e" fbc:charge="0" fbc:chemicalFormula="C35H56N7O17P3S"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_thex2eACP_ap" name="trans_Hex_2_enoyl_acyl_carrier_protein" compartment="ap" fbc:charge="0" fbc:chemicalFormula="C17H29N2O8PRS"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_thf_c" name="5_6_7_8_Tetrahydrofolate" compartment="c" fbc:charge="0" fbc:chemicalFormula="C19H21N7O6"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_thf_m" name="5_6_7_8_Tetrahydrofolate" compartment="m" fbc:charge="0" fbc:chemicalFormula="C19H21N7O6"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_thfglu_c" name="Tetrahydrofolyl_Glu_2" compartment="c" fbc:charge="0" fbc:chemicalFormula="C24H27N8O9"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_thm_c" name="Thiamin" compartment="c" fbc:charge="0" fbc:chemicalFormula="C12H17N4OS"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_thm_e" name="Thiamin" compartment="e" fbc:charge="0" fbc:chemicalFormula="C12H17N4OS"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_thmmp_c" name="Thiamin_monophosphate" compartment="c" fbc:charge="0" fbc:chemicalFormula="C12H16N4O4PS"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_thmpp_c" name="Thiamine_diphosphate" compartment="c" fbc:charge="0" fbc:chemicalFormula="C12H16N4O7P2S"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_thr__L_c" name="L_Threonine" compartment="c" fbc:charge="0" fbc:chemicalFormula="C4H9NO3"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_thr__L_e" name="L_Threonine" compartment="e" fbc:charge="0" fbc:chemicalFormula="C4H9NO3"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_thrtrna_c" name="L_Threonyl_tRNA_Thr" compartment="c" fbc:charge="0" fbc:chemicalFormula="C4H8NO2R"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_tmrs2eACP_ap" name="trans_Tetradec_2_enoyl_acyl_carrier_protein" compartment="ap" fbc:charge="0" fbc:chemicalFormula="C25H45N2O8PRS"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_toct2eACP_ap" name="trans_Oct_2_enoyl_acyl_carrier_protein" compartment="ap" fbc:charge="0" fbc:chemicalFormula="C19H33N2O8PRS"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_toctd2eACP_ap" name="trans_octadec_2_enoyl_acyl_carrier_protein" compartment="ap" fbc:charge="0" fbc:chemicalFormula="C29H53N2O8PRS"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_tpalm2eACP_ap" name="trans_Hexadec_2_enoyl_acyl_carrier_protein" compartment="ap" fbc:charge="0" fbc:chemicalFormula="C27H49N2O8PRS"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_trdox_c" name="Oxidized_thioredoxin" compartment="c" fbc:charge="0" fbc:chemicalFormula="X"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_trdrd_c" name="Reduced_thioredoxin" compartment="c" fbc:charge="0" fbc:chemicalFormula="XH2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_trdrd_m" name="Reduced_thioredoxin" compartment="m" fbc:charge="0" fbc:chemicalFormula="XH2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_trnaala_c" name="tRNA_Ala" compartment="c" fbc:charge="0" fbc:chemicalFormula="R"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_trnaarg_c" name="tRNA_Arg" compartment="c" fbc:charge="0" fbc:chemicalFormula="R"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_trnaasn_c" name="tRNA_Asn" compartment="c" fbc:charge="0" fbc:chemicalFormula="C10H17O10PR2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_trnaasp_c" name="tRNA_Asp" compartment="c" fbc:charge="0" fbc:chemicalFormula="R"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_trnacys_c" name="tRNA_Cys" compartment="c" fbc:charge="0" fbc:chemicalFormula="R"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_trnagln_c" name="tRNA_Gln" compartment="c" fbc:charge="0" fbc:chemicalFormula="R"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_trnaglu_c" name="tRNA_Glu" compartment="c" fbc:charge="0" fbc:chemicalFormula="R"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_trnagly_c" name="tRNA_Gly" compartment="c" fbc:charge="0" fbc:chemicalFormula="R"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_trnahis_c" name="tRNA_His" compartment="c" fbc:charge="0" fbc:chemicalFormula="R"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_trnaile_c" name="tRNA_Ile" compartment="c" fbc:charge="0" fbc:chemicalFormula="R"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_trnaleu_c" name="tRNA_Leu" compartment="c" fbc:charge="0" fbc:chemicalFormula="R"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_trnalys_c" name="tRNA_Lys" compartment="c" fbc:charge="0" fbc:chemicalFormula="R"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_trnamet_c" name="tRNA_Met" compartment="c" fbc:charge="0" fbc:chemicalFormula="R"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_trnaphe_c" name="tRNA_Phe" compartment="c" fbc:charge="0" fbc:chemicalFormula="R"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_trnapro_c" name="tRNA_Pro" compartment="c" fbc:charge="0" fbc:chemicalFormula="R"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_trnasecys_c" name="tRNA_SeCys" compartment="c" fbc:charge="0" fbc:chemicalFormula="R"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_trnaser_c" name="tRNA_Ser" compartment="c" fbc:charge="0" fbc:chemicalFormula="R"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_trnathr_c" name="tRNA_Thr" compartment="c" fbc:charge="0" fbc:chemicalFormula="R"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_trnatrp_c" name="tRNA_Trp" compartment="c" fbc:charge="0" fbc:chemicalFormula="R"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_trnatyr_c" name="tRNA_Tyr" compartment="c" fbc:charge="0" fbc:chemicalFormula="R"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_trnaval_c" name="tRNA_Val" compartment="c" fbc:charge="0" fbc:chemicalFormula="R"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_trp__L_c" name="L_Tryptophan" compartment="c" fbc:charge="0" fbc:chemicalFormula="C11H12N2O2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_trp__L_e" name="L_Tryptophan" compartment="e" fbc:charge="0" fbc:chemicalFormula="C11H12N2O2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ttc_ap" name="tetracosanoate_n_C240" compartment="ap" fbc:charge="0" fbc:chemicalFormula="C24H47O2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ttdca_ap" name="tetradecanoate_n_C140" compartment="ap" fbc:charge="0" fbc:chemicalFormula="C14H27O2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ttdca_c" name="tetradecanoate_n_C140" compartment="c" fbc:charge="0" fbc:chemicalFormula="C14H27O2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ttdca_e" name="tetradecanoate_n_C140" compartment="e" fbc:charge="0" fbc:chemicalFormula="C14H27O2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ttdcea_ap" name="tetradecenoate_n_C141" compartment="ap" fbc:charge="0" fbc:chemicalFormula="C14H25O2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ttdcea_c" name="tetradecenoate_n_C141" compartment="c" fbc:charge="0" fbc:chemicalFormula="C14H25O2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ttdcea_e" name="tetradecenoate_n_C141" compartment="e" fbc:charge="0" fbc:chemicalFormula="C14H25O2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_tyr__L_c" name="L_Tyrosine" compartment="c" fbc:charge="0" fbc:chemicalFormula="C9H11NO3"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_tyr__L_e" name="L_Tyrosine" compartment="e" fbc:charge="0" fbc:chemicalFormula="C9H11NO3"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_tyr__L_m" name="L_Tyrosine" compartment="m" fbc:charge="0" fbc:chemicalFormula="C9H11NO3"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_tyrtrna_c" name="L_Tyrosyl_tRNA_Tyr" compartment="c" fbc:charge="0" fbc:chemicalFormula="C9H10NO2R"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_uacgam_c" name="UDP_N_acetyl_D_glucosamine" compartment="c" fbc:charge="0" fbc:chemicalFormula="C17H25N3O17P2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_udp_c" name="UDP" compartment="c" fbc:charge="0" fbc:chemicalFormula="C9H11N2O12P2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_udpg_c" name="UDPglucose" compartment="c" fbc:charge="0" fbc:chemicalFormula="C15H22N2O17P2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ump_c" name="UMP" compartment="c" fbc:charge="0" fbc:chemicalFormula="C9H11N2O9P"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_up4u_c" name="P1,P4-Bis(5-uridyl) tetraphosphate" compartment="c" fbc:charge="[]" fbc:chemicalFormula="['C18H26N4O23P4']"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_uppg3_ap" name="Uroporphyrinogen_III" compartment="ap" fbc:charge="0" fbc:chemicalFormula="C40H36N4O16"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ura_c" name="Uracil" compartment="c" fbc:charge="0" fbc:chemicalFormula="C4H4N2O2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_urea_c" name="Urea" compartment="c" fbc:charge="0" fbc:chemicalFormula="CH4N2O"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_urea_e" name="Urea" compartment="e" fbc:charge="0" fbc:chemicalFormula="CH4N2O"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_uri_c" name="Uridine" compartment="c" fbc:charge="0" fbc:chemicalFormula="C9H12N2O6"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_utp_c" name="UTP" compartment="c" fbc:charge="0" fbc:chemicalFormula="C9H11N2O15P3"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_val__L_c" name="L_Valine" compartment="c" fbc:charge="0" fbc:chemicalFormula="C5H11NO2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_val__L_e" name="L_Valine" compartment="e" fbc:charge="0" fbc:chemicalFormula="C5H11NO2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_valtrna_c" name="L_Valyl_tRNA_Val" compartment="c" fbc:charge="0" fbc:chemicalFormula="C5H10NOR"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_xan_c" name="Xanthine" compartment="c" fbc:charge="0" fbc:chemicalFormula="C5H4N4O2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_xan_e" name="Xanthine" compartment="e" fbc:charge="0" fbc:chemicalFormula="C5H4N4O2"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_xmp_c" name="Xanthosine_5_phosphate" compartment="c" fbc:charge="0" fbc:chemicalFormula="C10H11N4O9P"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_xolest2_c" name="Cholesterol ester" compartment="c" fbc:charge="[0]" fbc:chemicalFormula="['C24H46NO7RCO']"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_xolest2_e" name="Cholesterol ester" compartment="e" fbc:charge="[0]" fbc:chemicalFormula="['C24H46NO7RCO']"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_xtsn_c" name="Xanthosine" compartment="c" fbc:charge="0" fbc:chemicalFormula="C10H12N4O6"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_xu5p__D_c" name="D_Xylulose_5_phosphate" compartment="c" fbc:charge="0" fbc:chemicalFormula="C5H9O8P"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pail_e" name="phosphatidylinositol" compartment="e" fbc:charge="[-1]" fbc:chemicalFormula="['C9H16O9PRCO2R2CO2']"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_g3pc_e" name="g3pc[e]" compartment="e" fbc:charge="0"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_g3pi_e" name="g3pi[e]" compartment="e" fbc:charge="0"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_g3ps_e" name="g3ps[e]" compartment="e" fbc:charge="0"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_dolichol_e" name="dolichol[e]" compartment="e" fbc:charge="0"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_seln_e" name="seln[e]" compartment="e" fbc:charge="0"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_2agpe120_e" name="2agpe120[e]" compartment="e" fbc:charge="0"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_2agpe140_e" name="2agpe140[e]" compartment="e" fbc:charge="0"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_2agpe141_e" name="2agpe141[e]" compartment="e" fbc:charge="0"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_2agpe160_e" name="2agpe160[e]" compartment="e" fbc:charge="0"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_2agpe161_e" name="2agpe161[e]" compartment="e" fbc:charge="0"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_2agpe180_e" name="2agpe180[e]" compartment="e" fbc:charge="0"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_2agpe181_e" name="2agpe181[e]" compartment="e" fbc:charge="0"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_2agpg120_e" name="2agpg120[e]" compartment="e" fbc:charge="0"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_2agpg140_e" name="2agpg140[e]" compartment="e" fbc:charge="0"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_2agpg141_e" name="2agpg141[e]" compartment="e" fbc:charge="0"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_2agpg160_e" name="2agpg160[e]" compartment="e" fbc:charge="0"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_2agpg161_e" name="2agpg161[e]" compartment="e" fbc:charge="0"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_2agpg180_e" name="2agpg180[e]" compartment="e" fbc:charge="0"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_2agpg181_e" name="2agpg181[e]" compartment="e" fbc:charge="0"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_2ddecg3p_e" name="2ddecg3p[e]" compartment="e" fbc:charge="0"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_gdp_ap" name="gdp[ap]" compartment="ap" fbc:charge="0"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_gtp_ap" name="gtp[ap]" compartment="ap" fbc:charge="0"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_mi13456p_e" name="mi13456p[e]" compartment="e" fbc:charge="0"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_mi1345p_e" name="mi1345p[e]" compartment="e" fbc:charge="0"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_mi134p_e" name="mi134p[e]" compartment="e" fbc:charge="0"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_mi1456p_e" name="mi1456p[e]" compartment="e" fbc:charge="0"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_mi145p_e" name="mi145p[e]" compartment="e" fbc:charge="0"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_mi14p_e" name="mi14p[e]" compartment="e" fbc:charge="0"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_mi1p__D_e" name="mi1p_D[e]" compartment="e" fbc:charge="0"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_mi34p_e" name="mi34p[e]" compartment="e" fbc:charge="0"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_mi4p__D_e" name="mi4p_D[e]" compartment="e" fbc:charge="0"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_dimp_e" name="dimp[e]" compartment="e" fbc:charge="0"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_apoACP_ap" name="apoACP[ap]" compartment="ap" fbc:charge="0"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pap_ap" name="pap[ap]" compartment="ap" fbc:charge="0"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_acACP_ap" name="acACP[ap]" compartment="ap" fbc:charge="0"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_Asn_X_Ser_Thr_e" name="Asn_X_Ser/Thr[e]" compartment="e" fbc:charge="0"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_citr__L_c" name="citrul[c]" compartment="c" fbc:charge="0"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_lald__D_c" name="lald_D[c]" compartment="c" fbc:charge="0"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_udcpdp_c" name="udcpdp[c]" compartment="c" fbc:charge="0"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_15dap_c" name="15dap[c]" compartment="c" fbc:charge="0"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_argtrna_c" name="argtrna[c]" compartment="c" fbc:charge="0"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_fadh2_c" name="fadh2[c]" compartment="c" fbc:charge="0"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_nh3_c" name="nh3[c]" compartment="c" fbc:charge="0"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_glu__L_ap" name="glu_L[ap]" compartment="ap" fbc:charge="0"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_akg_ap" name="akg[ap]" compartment="ap" fbc:charge="0"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_nh3_ap" name="nh3[ap]" compartment="ap" fbc:charge="0"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_naglc2p__L_c" name="naglc2p_L[c]" compartment="c" fbc:charge="0"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_m4mpdol__L_c" name="m4mpdol_L[c]" compartment="c" fbc:charge="0"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_m8mpdol__L_c" name="m8mpdol_L[c]" compartment="c" fbc:charge="0"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_pheme_fv" name="pheme[fv]" compartment="v" fbc:charge="0"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_psertrna_sec_c" name="O-Phosphoseryl-tRNA(Sec)" compartment="c" fbc:charge="[]" fbc:chemicalFormula="[]"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_sectrna_c" name="sectrna[c]" compartment="c" fbc:charge="0"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_trptrna_c" name="trptrna[c]" compartment="c" fbc:charge="0"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_34hpp_c" name="34hpp[c]" compartment="c" fbc:charge="0"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_glntrna_c" name="glntrna[c]" compartment="c" fbc:charge="0"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_s7p_c" name="s7p[c]" compartment="c" fbc:charge="0"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_dcmp_c" name="dcmp[c]" compartment="c" fbc:charge="0"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_mmet_c" name="mmet[c]" compartment="c" fbc:charge="0"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_hemozoin_fv" name="hemozoin" compartment="v" fbc:charge="[]" fbc:chemicalFormula="[]"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_hemozoin_e" name="hemozoin" compartment="e" fbc:charge="[]" fbc:chemicalFormula="[]"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_4pyrdx_c" name="pyrdat[c]" compartment="c" fbc:charge="0"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_gluside_e" name="D-glucosyl-N-acylsphingosine" compartment="e" fbc:charge="[0]" fbc:chemicalFormula="[]"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_lac__L_e" name="lac_L[e]" compartment="e" fbc:charge="0"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_sprm_c" name="sperm[c]" compartment="c" fbc:charge="0"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_fol_c" name="fol[c]" compartment="c" fbc:charge="0"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_asntrna_c" name="asntrna[c]" compartment="c" fbc:charge="0"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_phetrna_c" name="phetrna[c]" compartment="c" fbc:charge="0"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_mgacpail_c" name="Mannosyl-glucosaminyl-acylphosphatidylinositiol" compartment="c" fbc:charge="[0]" fbc:chemicalFormula="[]"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_tag6p__D_c" name="tag6p_D[c]" compartment="c" fbc:charge="0"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_tagdp__D_c" name="tagdp_D[c]" compartment="c" fbc:charge="0"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_protrna_c" name="protrna[c]" compartment="c" fbc:charge="0"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_asptrna_c" name="asptrna[c]" compartment="c" fbc:charge="0"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_glytrna_c" name="glytrna[c]" compartment="c" fbc:charge="0"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_lystrna_c" name="lystrna[c]" compartment="c" fbc:charge="0"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_gp4g_c" name="gp4g[c]" compartment="c" fbc:charge="0"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ap4a_c" name="ap4a[c]" compartment="c" fbc:charge="0"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_progly_e" name="progly[e]" compartment="e" fbc:charge="0"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_idp_c" name="idp[c]" compartment="c" fbc:charge="0"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_sphmyln_e" name="Sphingomyelin (generic)" compartment="e" fbc:charge="[0]" fbc:chemicalFormula="['C23H48N2O5PRCO']"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_sphmyln_hs_c" name="sphmyln_host[c]" compartment="c" fbc:charge="0"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_hmfurn_c" name="hmfurn[c]" compartment="c" fbc:charge="0"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_o2s_c" name="o2s[c]" compartment="c" fbc:charge="0"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_o2s_m" name="o2s[m]" compartment="m" fbc:charge="0"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_gthox_ap" name="gthox[ap]" compartment="ap" fbc:charge="0"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_gthrd_ap" name="gthrd[ap]" compartment="ap" fbc:charge="0"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_h2o2_ap" name="h2o2[ap]" compartment="ap" fbc:charge="0"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ROOH_ap" name="hydroperoxy group on protein" compartment="ap" fbc:charge="[]" fbc:chemicalFormula="[]"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ROH_ap" name="hydroxyl group on protein" compartment="ap" fbc:charge="[]" fbc:chemicalFormula="[]"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_protein_t_c" name="glutathione-protein conjugate (intracellular) " compartment="c" fbc:charge="[]" fbc:chemicalFormula="[]"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_gthox_protein_c" name="oxidized glutathione and protein" compartment="c" fbc:charge="[]" fbc:chemicalFormula="[]"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_gthox_protein_e" name="oxidized glutathione and protein" compartment="e" fbc:charge="[]" fbc:chemicalFormula="[]"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_protein_t_e" name="glutathione-protein conjugate (extracellular) " compartment="e" fbc:charge="[]" fbc:chemicalFormula="[]"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ROOH_c" name="hydroperoxy group on protein" compartment="c" fbc:charge="[]" fbc:chemicalFormula="[]"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ROH_c" name="hydroxyl group on protein" compartment="c" fbc:charge="[]" fbc:chemicalFormula="[]"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ROOH_m" name="hydroperoxy group on protein" compartment="m" fbc:charge="[]" fbc:chemicalFormula="[]"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ROH_m" name="hydroxyl group on protein" compartment="m" fbc:charge="[]" fbc:chemicalFormula="[]"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_trdox_m" name="trdox[m]" compartment="m" fbc:charge="0"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_protdt_c" name="proteinSS[c]" compartment="c" fbc:charge="0"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_protds_c" name="proteinSHSH[c]" compartment="c" fbc:charge="0"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_protdt_ap" name="proteinSS[ap]" compartment="ap" fbc:charge="0"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_protds_ap" name="proteinSHSH[ap]" compartment="ap" fbc:charge="0"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_protdt_m" name="proteinSS[m]" compartment="m" fbc:charge="0"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_protds_m" name="proteinSHSH[m]" compartment="m" fbc:charge="0"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_gthrd_m" name="gthrd[m]" compartment="m" fbc:charge="0"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ser__L_m" name="ser_L[m]" compartment="m" fbc:charge="0"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_ser__L_ap" name="ser_L[ap]" compartment="ap" fbc:charge="0"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_thf_ap" name="thf[ap]" compartment="ap" fbc:charge="0"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_gly_ap" name="gly[ap]" compartment="ap" fbc:charge="0"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_mlthf_ap" name="mlthf[ap]" compartment="ap" fbc:charge="0"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_mlthf_e" name="mlthf[e]" compartment="e" fbc:charge="0"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_all_pc_c" name="Phosphatidylcholine (total)" compartment="c" fbc:charge="[]" fbc:chemicalFormula="[]"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_all_pe_c" name="Phosphatidylethanolamine (total)" compartment="c" fbc:charge="[]" fbc:chemicalFormula="[]"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_all_ps_c" name="Phosphatidylserine (total)" compartment="c" fbc:charge="[]" fbc:chemicalFormula="[]"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_all_pi_c" name="Phosphatidylinositol  (total)" compartment="c" fbc:charge="[]" fbc:chemicalFormula="[]"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_all_pg_c" name="Phosphatidylglycerol (total)" compartment="c" fbc:charge="[]" fbc:chemicalFormula="[]"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_all_apg_c" name="acyl - phosphatidylglycerol (total)" compartment="c" fbc:charge="[]" fbc:chemicalFormula="[]"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_all_dgl_c" name="diacyl - phosphatidylglycerol (total)" compartment="c" fbc:charge="[]" fbc:chemicalFormula="[]"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_acoa_c" name="acoa[c]" compartment="c" fbc:charge="0"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_malcoa_c" name="malcoa[c]" compartment="c" fbc:charge="0"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_bm_protein_c" name="protein[c]" compartment="c" fbc:charge="0"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_protein_e" name="protein[e]" compartment="e" fbc:charge="0"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_bm_lipid_c" name="lipid[c]" compartment="c" fbc:charge="0"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_biomass_c" name="biomass[c]" compartment="c" fbc:charge="0"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_heme_degraded_c" name="degraded heme" compartment="c" fbc:charge="[]" fbc:chemicalFormula="[]"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_heme_degraded_fv" name="degraded heme" compartment="v" fbc:charge="[]" fbc:chemicalFormula="[]"/>
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_adprib_e" name="ADPribose C15H21N5O14P2" metaid="M_adprib_e" sboTerm="SBO:0000247" compartment="e" fbc:charge="-2" fbc:chemicalFormula="C15H21N5O14P2">
         <sbml:annotation xmlns:sbml="http://www.sbml.org/sbml/level3/version1/core">
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
             <rdf:Description rdf:about="#M_adprib_e">
@@ -1045,7 +1045,7 @@
           </rdf:RDF>
         </sbml:annotation>
       </species>
-      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_adprib_c" name="ADPribose C15H21N5O14P2" metaid="M_adprib_c" sboTerm="SBO:0000247" compartment="cytosol" fbc:charge="-2" fbc:chemicalFormula="C15H21N5O14P2">
+      <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_adprib_c" name="ADPribose C15H21N5O14P2" metaid="M_adprib_c" sboTerm="SBO:0000247" compartment="c" fbc:charge="-2" fbc:chemicalFormula="C15H21N5O14P2">
         <sbml:annotation xmlns:sbml="http://www.sbml.org/sbml/level3/version1/core">
           <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
             <rdf:Description rdf:about="#M_adprib_c">

--- a/iPfal19.xml
+++ b/iPfal19.xml
@@ -29,11 +29,11 @@
       <parameter constant="true" id="R_MLTHFte3_lower_bound" sboTerm="SBO:0000625" units="mmol_per_gDW_per_hr" value="-10"/>
     </listOfParameters>
     <listOfCompartments>
-      <compartment constant="true" id="cytosol" name=""/>
-      <compartment constant="true" id="extracellular" name=""/>
-      <compartment constant="true" id="apicoplast" name=""/>
-      <compartment constant="true" id="mitochondria" name=""/>
-      <compartment constant="true" id="food vacuole" name=""/>
+      <compartment constant="true" id="c" name="cytosol"/>
+      <compartment constant="true" id="e" name="extracellular"/>
+      <compartment constant="true" id="ap" name="apicoplast"/>
+      <compartment constant="true" id="m" name="mitochondria"/>
+      <compartment constant="true" id="v" name="vacuole"/>
     </listOfCompartments>
     <listOfSpecies>
       <species boundaryCondition="false" constant="false" hasOnlySubstanceUnits="false" id="M_10fthf_c" name="10_Formyltetrahydrofolate" compartment="cytosol" fbc:charge="0" fbc:chemicalFormula="C20H21N7O7"/>


### PR DESCRIPTION
The model could actually not be loaded in the latest cobrapy since `food vacuole` is not a valid SBML identifier. I made all compartment identifiers names and created new identifiers as customary in BiGG. I could not find an existing usage for apicoplast other than MNXC25 so I inserted `ap` for the id as some compound suffixes suggested.